### PR TITLE
Add EVE market data service and tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+eve_trader.sqlite3
+.env
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# VulnHawk Item Service
+
+This project collects EVE Online market data for Jita 4-4 and tracks
+personal trading performance using a local SQLite database.
+
+Features:
+- OAuth helpers for authenticated character access
+- SQLite schema for wallet, orders, assets and market snapshots
+- Region type seeding and Jita order snapshots
+- Trend calculations and scheduling helpers
+- Portfolio valuation and P/L plots
+
+Run `python -m py_compile $(git ls-files '*.py')` to verify syntax.

--- a/app/char_sync.py
+++ b/app/char_sync.py
@@ -1,0 +1,176 @@
+from datetime import datetime
+from .esi import BASE, get, paged
+from .db import connect
+from .config import DATASOURCE
+
+
+def sync_wallet_balance(con, char_id, token):
+    url = f"{BASE}/characters/{char_id}/wallet/"
+    data, hdrs, code = get(url, params={"datasource": DATASOURCE}, token=token)
+    if code == 304:
+        return
+    ts = datetime.utcnow().isoformat()
+    con.execute("INSERT OR REPLACE INTO wallet_snapshots (ts_utc, balance) VALUES (?, ?)", (ts, float(data)))
+    con.commit()
+
+
+def sync_wallet_journal(con, char_id, token, from_id=None):
+    url = f"{BASE}/characters/{char_id}/wallet/journal/"
+    params = {"datasource": DATASOURCE}
+    while True:
+        if from_id:
+            params["from_id"] = from_id
+        data, hdrs, _ = get(url, params=params, token=token)
+        if not data:
+            break
+        for row in data:
+            con.execute(
+                """
+                INSERT OR IGNORE INTO wallet_journal
+                  (id, ts_utc, amount, balance, ref_type, context_id, context_id_type, first_party_id, second_party_id, description)
+                VALUES (?,?,?,?,?,?,?,?,?,?)
+                """,
+                (
+                    row["id"],
+                    row["date"],
+                    row.get("amount", 0.0),
+                    row.get("balance"),
+                    row.get("ref_type"),
+                    row.get("context_id"),
+                    row.get("context_id_type"),
+                    row.get("first_party_id"),
+                    row.get("second_party_id"),
+                    row.get("description"),
+                ),
+            )
+        con.commit()
+        from_id = data[-1]["id"]
+
+
+def sync_wallet_transactions(con, char_id, token, from_id=None):
+    url = f"{BASE}/characters/{char_id}/wallet/transactions/"
+    params = {"datasource": DATASOURCE}
+    while True:
+        if from_id:
+            params["from_id"] = from_id
+        data, hdrs, _ = get(url, params=params, token=token)
+        if not data:
+            break
+        for row in data:
+            con.execute(
+                """
+                INSERT OR IGNORE INTO wallet_transactions
+                  (transaction_id, ts_utc, client_id, location_id, type_id, quantity, unit_price, is_buy, journal_ref_id)
+                VALUES (?,?,?,?,?,?,?,?,?)
+                """,
+                (
+                    row["transaction_id"],
+                    row["date"],
+                    row.get("client_id"),
+                    row.get("location_id"),
+                    row["type_id"],
+                    row["quantity"],
+                    row["unit_price"],
+                    1 if row["is_buy"] else 0,
+                    row.get("journal_ref_id"),
+                ),
+            )
+        con.commit()
+        from_id = data[-1]["transaction_id"]
+
+
+def sync_open_orders(con, char_id, token):
+    url = f"{BASE}/characters/{char_id}/orders/"
+    orders = []
+    for o in paged(url, params={"datasource": DATASOURCE}, token=token):
+        orders.append(o)
+        con.execute(
+            """
+            INSERT OR REPLACE INTO char_orders
+              (order_id, is_buy, region_id, location_id, type_id, price, volume_total, volume_remain, issued, duration, range, min_volume, escrow, last_seen, state)
+            VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,'open')
+            """,
+            (
+                o["order_id"],
+                1 if o["is_buy_order"] else 0,
+                o.get("region_id"),
+                o["location_id"],
+                o["type_id"],
+                o["price"],
+                o["volume_total"],
+                o["volume_remain"],
+                o["issued"],
+                o["duration"],
+                o.get("range"),
+                o.get("min_volume"),
+                o.get("escrow", 0.0),
+                datetime.utcnow().isoformat(),
+            ),
+        )
+    con.commit()
+    con.execute(
+        "UPDATE char_orders SET state='finished' WHERE state='open' AND last_seen < datetime('now','-2 hour')"
+    )
+    con.commit()
+
+
+def sync_order_history(con, char_id, token, page_limit=10):
+    url = f"{BASE}/characters/{char_id}/orders/history/"
+    page = 1
+    while page <= page_limit:
+        data, hdrs, _ = get(url, params={"datasource": DATASOURCE, "page": page}, token=token)
+        if not data:
+            break
+        for o in data:
+            con.execute(
+                """
+                INSERT OR REPLACE INTO char_orders
+                  (order_id, is_buy, region_id, location_id, type_id, price, volume_total, volume_remain, issued, duration, range, min_volume, escrow, last_seen, state)
+                VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                """,
+                (
+                    o["order_id"],
+                    1 if o["is_buy_order"] else 0,
+                    o.get("region_id"),
+                    o["location_id"],
+                    o["type_id"],
+                    o["price"],
+                    o["volume_total"],
+                    o["volume_remain"],
+                    o["issued"],
+                    o["duration"],
+                    o.get("range"),
+                    o.get("min_volume"),
+                    o.get("escrow", 0.0),
+                    datetime.utcnow().isoformat(),
+                    o.get("state", "finished"),
+                ),
+            )
+        con.commit()
+        pages = int(hdrs.get("X-Pages", "1"))
+        if page >= pages:
+            break
+        page += 1
+
+
+def sync_assets(con, char_id, token):
+    url = f"{BASE}/characters/{char_id}/assets/"
+    for row in paged(url, params={"datasource": DATASOURCE}, token=token):
+        con.execute(
+            """
+            INSERT OR REPLACE INTO assets
+              (item_id, type_id, quantity, is_singleton, location_id, location_type, location_flag, updated)
+            VALUES (?,?,?,?,?,?,?,?)
+            """,
+            (
+                row["item_id"],
+                row["type_id"],
+                row["quantity"],
+                1 if row.get("is_singleton") else 0,
+                row["location_id"],
+                row.get("location_type"),
+                row.get("location_flag"),
+                datetime.utcnow().isoformat(),
+            ),
+        )
+    con.commit()

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,15 @@
+STATION_ID = 60003760  # Jita 4-4
+REGION_ID = 10000002  # The Forge region
+DATASOURCE = "tranquility"
+
+# Fee parameters (adjust for structure vs NPC)
+VENUE = "npc"  # or "structure"
+SALES_TAX = 0.075 * 0.45  # Accounting V 2025
+BROKER_BUY = 0.01 if VENUE == "npc" else 0.005
+BROKER_SELL = BROKER_BUY
+RELIST_HAIRCUT = 0.002
+
+MOM_THRESHOLD = 0.12
+MIN_DAYS_TRADED = 26
+MIN_DAILY_VOL = 100
+SPREAD_BUFFER = 0.02

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,160 @@
+import sqlite3
+import pathlib
+
+DB_PATH = pathlib.Path("eve_trader.sqlite3")
+
+DDL = """
+PRAGMA journal_mode=WAL;
+CREATE TABLE IF NOT EXISTS meta (
+  key TEXT PRIMARY KEY,
+  value TEXT
+);
+
+CREATE TABLE IF NOT EXISTS wallet_snapshots (
+  ts_utc TEXT PRIMARY KEY,
+  balance REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS wallet_journal (
+  id INTEGER PRIMARY KEY,
+  ts_utc TEXT NOT NULL,
+  amount REAL NOT NULL,
+  balance REAL,
+  ref_type TEXT,
+  context_id INTEGER,
+  context_id_type TEXT,
+  first_party_id INTEGER,
+  second_party_id INTEGER,
+  description TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_journal_ts ON wallet_journal(ts_utc);
+
+CREATE TABLE IF NOT EXISTS wallet_transactions (
+  transaction_id INTEGER PRIMARY KEY,
+  ts_utc TEXT NOT NULL,
+  client_id INTEGER,
+  location_id INTEGER,
+  type_id INTEGER,
+  quantity INTEGER,
+  unit_price REAL,
+  is_buy INTEGER,
+  journal_ref_id INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_tx_type_ts ON wallet_transactions(type_id, ts_utc);
+
+CREATE TABLE IF NOT EXISTS char_orders (
+  order_id INTEGER PRIMARY KEY,
+  is_buy INTEGER,
+  region_id INTEGER,
+  location_id INTEGER,
+  type_id INTEGER,
+  price REAL,
+  volume_total INTEGER,
+  volume_remain INTEGER,
+  issued TEXT,
+  duration INTEGER,
+  range TEXT,
+  min_volume INTEGER,
+  escrow REAL,
+  last_seen TEXT,
+  state TEXT DEFAULT 'open'
+);
+
+CREATE TABLE IF NOT EXISTS assets (
+  item_id INTEGER PRIMARY KEY,
+  type_id INTEGER,
+  quantity INTEGER,
+  is_singleton INTEGER,
+  location_id INTEGER,
+  location_type TEXT,
+  location_flag TEXT,
+  updated TEXT
+);
+
+CREATE TABLE IF NOT EXISTS types (
+  type_id INTEGER PRIMARY KEY,
+  name TEXT,
+  group_id INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS type_valuations (
+  type_id INTEGER PRIMARY KEY,
+  quicksell_bid REAL,
+  mark_ask REAL,
+  updated TEXT
+);
+
+CREATE TABLE IF NOT EXISTS portfolio_daily (
+  day TEXT PRIMARY KEY,
+  wallet_balance REAL,
+  buy_escrow REAL,
+  sell_gross REAL,
+  inventory_quicksell REAL,
+  inventory_mark REAL,
+  nav_quicksell REAL,
+  nav_mark REAL
+);
+
+CREATE TABLE IF NOT EXISTS region_types (
+  region_id INTEGER NOT NULL,
+  type_id INTEGER NOT NULL,
+  first_seen TEXT NOT NULL,
+  last_seen TEXT NOT NULL,
+  PRIMARY KEY (region_id, type_id)
+);
+
+CREATE TABLE IF NOT EXISTS type_status (
+  type_id INTEGER PRIMARY KEY,
+  last_orders_refresh TEXT,
+  next_refresh TEXT,
+  tier TEXT,
+  update_interval_min INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS market_snapshots (
+  ts_utc TEXT NOT NULL,
+  type_id INTEGER NOT NULL,
+  best_bid REAL,
+  best_ask REAL,
+  bid_count INTEGER,
+  ask_count INTEGER,
+  jita_bid_units INTEGER,
+  jita_ask_units INTEGER,
+  PRIMARY KEY (ts_utc, type_id)
+);
+
+CREATE TABLE IF NOT EXISTS type_trends (
+  type_id INTEGER PRIMARY KEY,
+  last_history_ts TEXT,
+  mom_pct REAL,
+  vol_30d_avg REAL,
+  vol_prev30_avg REAL
+);
+
+CREATE TABLE IF NOT EXISTS realized_trades (
+  trade_id TEXT PRIMARY KEY,
+  ts_utc TEXT NOT NULL,
+  type_id INTEGER NOT NULL,
+  qty INTEGER NOT NULL,
+  sell_unit_price REAL NOT NULL,
+  cost_total REAL NOT NULL,
+  tax REAL NOT NULL,
+  broker_fee REAL NOT NULL,
+  pnl REAL NOT NULL
+);
+"""
+
+
+def connect():
+    con = sqlite3.connect(DB_PATH)
+    con.execute("PRAGMA foreign_keys=ON;")
+    return con
+
+
+def init_db():
+    con = connect()
+    con.executescript(DDL)
+    con.commit()
+    return con

--- a/app/esi.py
+++ b/app/esi.py
@@ -1,0 +1,39 @@
+import time
+import requests
+
+from .config import DATASOURCE
+
+BASE = "https://esi.evetech.net/latest"
+HEADERS = {"Accept": "application/json"}
+
+
+def get(url, params=None, etag=None, token=None):
+    headers = dict(HEADERS)
+    if etag:
+        headers["If-None-Match"] = etag
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    r = requests.get(url, params=params, headers=headers, timeout=30)
+    if r.status_code == 304:
+        return None, r.headers, 304
+    if r.status_code >= 400:
+        reset = int(r.headers.get("X-ESI-Error-Limit-Reset", "5"))
+        time.sleep(max(reset, 2))
+        r.raise_for_status()
+    return r.json(), r.headers, r.status_code
+
+
+def paged(url, params=None, token=None):
+    page = 1
+    while True:
+        p = dict(params or {})
+        p["page"] = page
+        data, hdrs, _ = get(url, params=p, token=token)
+        if not data:
+            break
+        for row in data:
+            yield row
+        pages = int(hdrs.get("X-Pages", "1"))
+        if page >= pages:
+            break
+        page += 1

--- a/app/jita_snapshots.py
+++ b/app/jita_snapshots.py
@@ -1,0 +1,90 @@
+import time
+from datetime import datetime
+import requests
+from .db import connect
+from .config import REGION_ID, DATASOURCE, STATION_ID
+from .esi import BASE
+
+
+def respect_error_limit(r):
+    rem = int(r.headers.get("X-ESI-Error-Limit-Remain", "100"))
+    rst = int(r.headers.get("X-ESI-Error-Limit-Reset", "10"))
+    if rem < 5:
+        time.sleep(max(rst, 2))
+
+
+def fetch_orders_for_type(tid, order_type):
+    url = f"{BASE}/markets/{REGION_ID}/orders/"
+    best, count, units = (None, 0, 0)
+    page = 1
+    while True:
+        params = {"order_type": order_type, "type_id": tid, "page": page, "datasource": DATASOURCE}
+        r = requests.get(url, params=params, timeout=30)
+        if r.status_code == 304:
+            break
+        r.raise_for_status()
+        data = r.json()
+        for o in data:
+            if o.get("location_id") != STATION_ID:
+                continue
+            if order_type == "buy":
+                if best is None or o["price"] > best:
+                    best = o["price"]
+            else:
+                if best is None or o["price"] < best:
+                    best = o["price"]
+            count += 1
+            units += o["volume_remain"]
+        pages = int(r.headers.get("X-Pages", "1"))
+        respect_error_limit(r)
+        if page >= pages:
+            break
+        page += 1
+    return best, count, units
+
+
+def refresh_one(con, tid):
+    bid, bid_c, bid_u = fetch_orders_for_type(tid, "buy")
+    ask, ask_c, ask_u = fetch_orders_for_type(tid, "sell")
+    ts = datetime.utcnow().isoformat()
+    con.execute(
+        """
+        INSERT OR REPLACE INTO market_snapshots
+          (ts_utc, type_id, best_bid, best_ask, bid_count, ask_count, jita_bid_units, jita_ask_units)
+        VALUES (?,?,?,?,?,?,?,?)
+        """,
+        (ts, tid, bid, ask, bid_c, ask_c, bid_u, ask_u),
+    )
+    con.execute(
+        """
+        INSERT OR IGNORE INTO type_status(type_id)
+        VALUES (?)
+        """,
+        (tid,),
+    )
+    con.execute(
+        """
+        UPDATE type_status SET last_orders_refresh=?, next_refresh=datetime('now', '+'||update_interval_min||' minutes')
+        WHERE type_id=?
+        """,
+        (ts, tid),
+    )
+
+
+def refresh_batch(limit_types=150):
+    con = connect()
+    rows = con.execute(
+        """
+        SELECT t.type_id FROM region_types t
+        LEFT JOIN type_status s ON s.type_id=t.type_id
+        WHERE t.region_id=?
+        ORDER BY COALESCE(s.last_orders_refresh,'1970-01-01') ASC
+        LIMIT ?
+        """,
+        (REGION_ID, limit_types),
+    ).fetchall()
+    for (tid,) in rows:
+        refresh_one(con, tid)
+        con.commit()
+        time.sleep(0.2)
+    con.close()

--- a/app/market.py
+++ b/app/market.py
@@ -1,0 +1,99 @@
+from datetime import datetime
+import pandas as pd
+from .esi import BASE, paged, get
+from .config import (
+    STATION_ID,
+    REGION_ID,
+    DATASOURCE,
+    SALES_TAX,
+    BROKER_SELL,
+    BROKER_BUY,
+    RELIST_HAIRCUT,
+    MOM_THRESHOLD,
+    MIN_DAYS_TRADED,
+    MIN_DAILY_VOL,
+    SPREAD_BUFFER,
+    VENUE,
+)
+
+
+def station_region_id(station_id):
+    data, _, _ = get(
+        f"{BASE}/universe/stations/{station_id}/", params={"datasource": DATASOURCE}
+    )
+    sys_id = data["system_id"]
+    sys, _, _ = get(
+        f"{BASE}/universe/systems/{sys_id}/", params={"datasource": DATASOURCE}
+    )
+    return sys["region_id"]
+
+
+def best_bid_ask_station(type_id, station_id, region_id):
+    url = f"{BASE}/markets/{region_id}/orders/"
+    params = {"datasource": DATASOURCE, "order_type": "all", "type_id": type_id}
+    buys, sells = [], []
+    for o in paged(url, params=params):
+        if o.get("location_id") != station_id:
+            continue
+        (buys if o["is_buy_order"] else sells).append(o)
+    best_bid = max((b["price"] for b in buys), default=None)
+    best_ask = min((s["price"] for s in sells), default=None)
+    return best_bid, best_ask
+
+
+def region_history(type_id, region_id):
+    url = f"{BASE}/markets/{region_id}/history/"
+    data, _, _ = get(url, params={"datasource": DATASOURCE, "type_id": type_id})
+    df = pd.DataFrame(data)
+    if df.empty:
+        return df
+    df["date"] = pd.to_datetime(df["date"])
+    df = df.sort_values("date")
+    return df
+
+
+def margin_after_fees(buy_px, sell_px):
+    return sell_px * (1 - SALES_TAX - BROKER_SELL - RELIST_HAIRCUT) - buy_px * (
+        1 + BROKER_BUY
+    )
+
+
+def mom_uplift(df):
+    if len(df) < 60:
+        return None
+    last30 = df.tail(30)
+    prev30 = df.iloc[-60:-30]
+    if (last30["order_count"] > 0).sum() < MIN_DAYS_TRADED:
+        return None
+    if (prev30["order_count"] > 0).sum() < MIN_DAYS_TRADED:
+        return None
+    m_now = last30["average"].mean()
+    m_prev = prev30["average"].mean()
+    return (m_now / m_prev) - 1.0
+
+
+def evaluate_type(type_id):
+    reg_id = REGION_ID if REGION_ID else station_region_id(STATION_ID)
+    df = region_history(type_id, reg_id)
+    if df.empty or df["volume"].tail(30).mean() < MIN_DAILY_VOL:
+        return None
+    uplift = mom_uplift(df)
+    if uplift is None or uplift < MOM_THRESHOLD:
+        return None
+    bid, ask = best_bid_ask_station(type_id, STATION_ID, reg_id)
+    if bid is None or ask is None:
+        return None
+    net = margin_after_fees(buy_px=bid, sell_px=ask)
+    net_pct = net / bid
+    break_even = (1 + BROKER_BUY) / (1 - SALES_TAX - BROKER_SELL) - 1
+    if net_pct < (break_even + SPREAD_BUFFER):
+        return None
+    daily_isk = df.tail(30)["volume"].mean() * df.tail(7)["average"].mean()
+    return {
+        "type_id": type_id,
+        "uplift_mom": uplift,
+        "net_spread_pct": net_pct,
+        "daily_isk_capacity": daily_isk,
+        "best_bid": bid,
+        "best_ask": ask,
+    }

--- a/app/pnl.py
+++ b/app/pnl.py
@@ -1,0 +1,124 @@
+from collections import deque, defaultdict
+from datetime import datetime
+from .db import connect
+
+
+def load_transactions(con):
+    return con.execute(
+        """
+        SELECT ts_utc, is_buy, type_id, quantity, unit_price, location_id, transaction_id, journal_ref_id
+        FROM wallet_transactions ORDER BY ts_utc ASC
+        """
+    ).fetchall()
+
+
+def load_journal(con):
+    taxes = con.execute(
+        "SELECT ts_utc, ABS(amount) FROM wallet_journal WHERE ref_type='transaction_tax' ORDER BY ts_utc"
+    ).fetchall()
+    brokers = con.execute(
+        "SELECT ts_utc, ABS(amount) FROM wallet_journal WHERE ref_type='brokers_fee' ORDER BY ts_utc"
+    ).fetchall()
+    return taxes, brokers
+
+
+def load_orders(con):
+    return con.execute(
+        "SELECT order_id, type_id, location_id, price, issued, volume_total FROM char_orders WHERE is_buy=0"
+    ).fetchall()
+
+
+def pnl_fifo():
+    con = connect()
+    tx = load_transactions(con)
+    taxes, brokers = load_journal(con)
+    orders = load_orders(con)
+
+    broker_events = [(datetime.fromisoformat(t), fee) for t, fee in brokers]
+    sell_orders = []
+    for o in orders:
+        sell_orders.append(
+            {
+                "order_id": o[0],
+                "type_id": o[1],
+                "location_id": o[2],
+                "price": o[3],
+                "issued": datetime.fromisoformat(o[4]),
+                "vol_total": o[5],
+                "vol_filled": 0,
+                "broker_fee": 0.0,
+            }
+        )
+    for t, fee in broker_events:
+        candidates = [o for o in sell_orders if abs((o["issued"] - t).total_seconds()) <= 120]
+        if candidates:
+            o = min(candidates, key=lambda x: abs((x["issued"] - t).total_seconds()))
+            o["broker_fee"] += fee
+
+    tax_events = [(datetime.fromisoformat(t), tax) for t, tax in taxes]
+
+    def nearest_tax(ts):
+        if not tax_events:
+            return 0.0
+        candidates = [
+            (abs((ts - tt).total_seconds()), tax)
+            for tt, tax in tax_events
+            if abs((ts - tt).total_seconds()) <= 5
+        ]
+        return min(candidates)[1] if candidates else 0.0
+
+    inventory = defaultdict(deque)
+    realized = []
+    for ts_s, is_buy, type_id, qty, unit_price, loc, txid, jref in tx:
+        ts = datetime.fromisoformat(ts_s)
+        if is_buy:
+            inventory[type_id].append([qty, unit_price])
+        else:
+            remaining = qty
+            sell_gross = unit_price * qty
+            sell_order_candidates = [
+                o
+                for o in sell_orders
+                if o["type_id"] == type_id and o["location_id"] == loc and o["issued"] <= ts
+            ]
+            broker_alloc = 0.0
+            if sell_order_candidates:
+                o = min(sell_order_candidates, key=lambda x: abs((ts - x["issued"]).total_seconds()))
+                portion = min(qty, o["vol_total"] - o["vol_filled"]) / max(1, o["vol_total"])
+                broker_alloc = o["broker_fee"] * portion
+                o["vol_filled"] += min(qty, o["vol_total"] - o["vol_filled"])
+            tax = nearest_tax(ts)
+            cost = 0.0
+            while remaining > 0 and inventory[type_id]:
+                lot = inventory[type_id][0]
+                take = min(remaining, lot[0])
+                cost += take * lot[1]
+                lot[0] -= take
+                remaining -= take
+                if lot[0] == 0:
+                    inventory[type_id].popleft()
+            realized.append(
+                (
+                    f"{txid}",
+                    ts_s,
+                    type_id,
+                    qty,
+                    unit_price,
+                    cost,
+                    tax,
+                    broker_alloc,
+                    sell_gross - cost - tax - broker_alloc,
+                )
+            )
+    for row in realized:
+        con.execute(
+            """
+            INSERT OR REPLACE INTO realized_trades
+              (trade_id, ts_utc, type_id, qty, sell_unit_price, cost_total, tax, broker_fee, pnl)
+            VALUES (?,?,?,?,?,?,?,?,?)
+            """,
+            row,
+        )
+    con.commit()
+    con.close()
+    return realized

--- a/app/reports.py
+++ b/app/reports.py
@@ -1,0 +1,54 @@
+import sqlite3
+import pandas as pd
+import matplotlib.pyplot as plt
+
+from .db import connect
+
+
+def plot_realized_pnl_daily(savepath="realized_pnl_daily.png"):
+    con = connect()
+    df = pd.read_sql_query(
+        """
+        SELECT date(ts_utc) AS d, SUM(pnl) AS pnl
+        FROM realized_trades
+        GROUP BY date(ts_utc)
+        ORDER BY d
+        """,
+        con,
+    )
+    con.close()
+    if df.empty:
+        print("No realized trades yet.")
+        return
+    plt.figure()
+    plt.plot(df["d"], df["pnl"])
+    plt.title("Realized P/L per day")
+    plt.xlabel("Day")
+    plt.ylabel("ISK")
+    plt.xticks(rotation=45, ha="right")
+    plt.tight_layout()
+    plt.savefig(savepath)
+    print(f"Saved {savepath}")
+
+
+def plot_nav(savepath="nav_quicksell.png"):
+    con = connect()
+    df = pd.read_sql_query(
+        """
+        SELECT day, nav_quicksell FROM portfolio_daily ORDER BY day
+        """,
+        con,
+    )
+    con.close()
+    if df.empty:
+        print("No snapshots yet.")
+        return
+    plt.figure()
+    plt.plot(df["day"], df["nav_quicksell"])
+    plt.title("NAV (quicksell)")
+    plt.xlabel("Day")
+    plt.ylabel("ISK")
+    plt.xticks(rotation=45, ha="right")
+    plt.tight_layout()
+    plt.savefig(savepath)
+    print(f"Saved {savepath}")

--- a/app/run_character_sync.py
+++ b/app/run_character_sync.py
@@ -1,0 +1,38 @@
+from .db import init_db, connect
+from .char_sync import (
+    sync_wallet_balance,
+    sync_wallet_journal,
+    sync_wallet_transactions,
+    sync_open_orders,
+    sync_order_history,
+    sync_assets,
+)
+from .valuation import refresh_type_valuations, compute_portfolio_snapshot
+
+CHAR_ID = 0  # replace with your character id
+TOKEN = ""  # replace with access token
+
+
+def main():
+    con = init_db()
+    sync_wallet_balance(con, CHAR_ID, TOKEN)
+    sync_wallet_journal(con, CHAR_ID, TOKEN)
+    sync_wallet_transactions(con, CHAR_ID, TOKEN)
+    sync_open_orders(con, CHAR_ID, TOKEN)
+    sync_order_history(con, CHAR_ID, TOKEN)
+    sync_assets(con, CHAR_ID, TOKEN)
+    cur = con.cursor()
+    type_ids = set(
+        t
+        for (t,) in cur.execute(
+            "SELECT DISTINCT type_id FROM assets UNION SELECT DISTINCT type_id FROM char_orders"
+        )
+    )
+    if type_ids:
+        refresh_type_valuations(con, sorted(type_ids))
+    snap = compute_portfolio_snapshot(con)
+    print("Portfolio:", snap)
+
+
+if __name__ == "__main__":
+    main()

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -1,0 +1,56 @@
+import time
+from .db import connect
+from .jita_snapshots import refresh_one
+from .trends import compute_mom, region_history
+from .config import REGION_ID
+
+
+TIERS = {"A": 90, "B": 240, "C": 360, "D": 1440}
+
+
+def classify_tier(vol):
+    if vol >= 5000:
+        return "A"
+    if vol >= 1000:
+        return "B"
+    if vol >= 100:
+        return "C"
+    return "D"
+
+
+def fill_queue_from_trends(max_types=500):
+    con = connect()
+    rows = con.execute(
+        "SELECT type_id, vol_30d_avg FROM type_trends ORDER BY vol_30d_avg DESC LIMIT ?",
+        (max_types,),
+    ).fetchall()
+    for tid, v in rows:
+        tier = classify_tier(v or 0)
+        con.execute(
+            """
+            INSERT INTO type_status(type_id, tier, update_interval_min)
+            VALUES (?,?,?)
+            ON CONFLICT(type_id) DO UPDATE SET tier=excluded.tier, update_interval_min=excluded.update_interval_min
+            """,
+            (tid, tier, TIERS[tier]),
+        )
+    con.commit()
+    con.close()
+
+
+def run_tick(max_calls=200):
+    con = connect()
+    due = con.execute(
+        """
+        SELECT type_id FROM type_status
+        WHERE next_refresh IS NULL OR next_refresh <= datetime('now')
+        ORDER BY COALESCE(last_orders_refresh,'1970-01-01') ASC
+        LIMIT ?
+        """,
+        (max_calls,),
+    ).fetchall()
+    for (tid,) in due:
+        refresh_one(con, tid)
+        con.commit()
+        time.sleep(0.2)
+    con.close()

--- a/app/trends.py
+++ b/app/trends.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+from .db import connect
+from .config import REGION_ID, DATASOURCE
+from .esi import BASE
+import requests
+
+
+def region_history(tid):
+    r = requests.get(
+        f"{BASE}/markets/{REGION_ID}/history/",
+        params={"type_id": tid, "datasource": DATASOURCE},
+        timeout=30,
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def compute_mom(hist):
+    if len(hist) < 60:
+        return None
+    last30 = hist[-30:]
+    prev30 = hist[-60:-30]
+    m_now = sum(d["average"] for d in last30) / 30.0
+    m_prev = sum(d["average"] for d in prev30) / 30.0
+    v_now = sum(d["volume"] for d in last30) / 30.0
+    v_prev = sum(d["volume"] for d in prev30) / 30.0
+    return m_now / m_prev - 1.0, v_now, v_prev
+
+
+def refresh_trends(limit_types=300):
+    con = connect()
+    rows = con.execute(
+        "SELECT type_id FROM region_types WHERE region_id=? LIMIT ?",
+        (REGION_ID, limit_types),
+    ).fetchall()
+    now = datetime.utcnow().isoformat()
+    for (tid,) in rows:
+        hist = region_history(tid)
+        mom = compute_mom(hist)
+        if mom:
+            mom_pct, vnow, vprev = mom
+            con.execute(
+                """
+                INSERT OR REPLACE INTO type_trends
+                   (type_id, last_history_ts, mom_pct, vol_30d_avg, vol_prev30_avg)
+                VALUES (?,?,?,?,?)
+                """,
+                (tid, now, mom_pct, vnow, vprev),
+            )
+    con.commit()
+    con.close()

--- a/app/types_sync.py
+++ b/app/types_sync.py
@@ -1,0 +1,29 @@
+import sqlite3
+from datetime import datetime
+from .esi import BASE, paged
+from .config import REGION_ID, DATASOURCE
+from .db import connect
+
+
+def seed_region_types():
+    con = connect()
+    now = datetime.utcnow().isoformat()
+    url = f"{BASE}/markets/{REGION_ID}/types/"
+    for tid in paged(url, params={"datasource": DATASOURCE}):
+        con.execute(
+            """
+            INSERT INTO region_types(region_id, type_id, first_seen, last_seen)
+            VALUES (?,?,?,?)
+            ON CONFLICT(region_id, type_id) DO UPDATE SET last_seen=excluded.last_seen
+            """,
+            (REGION_ID, tid, now, now),
+        )
+        con.execute(
+            """
+            INSERT OR IGNORE INTO type_status(type_id, tier, update_interval_min)
+            VALUES (?, 'C', 360)
+            """,
+            (tid,),
+        )
+    con.commit()
+    con.close()

--- a/app/valuation.py
+++ b/app/valuation.py
@@ -1,0 +1,80 @@
+from datetime import datetime
+from .db import connect
+from .config import STATION_ID, REGION_ID, SALES_TAX, BROKER_SELL
+from .market import best_bid_ask_station
+
+
+def refresh_type_valuations(con, type_ids):
+    for tid in type_ids:
+        bid, ask = best_bid_ask_station(tid, STATION_ID, REGION_ID)
+        con.execute(
+            """
+            INSERT OR REPLACE INTO type_valuations (type_id, quicksell_bid, mark_ask, updated)
+            VALUES (?,?,?,?)
+            """,
+            (tid, bid or 0.0, ask or 0.0, datetime.utcnow().isoformat()),
+        )
+    con.commit()
+
+
+def compute_portfolio_snapshot(con):
+    cur = con.cursor()
+    bal = cur.execute(
+        "SELECT balance FROM wallet_snapshots ORDER BY ts_utc DESC LIMIT 1"
+    ).fetchone()
+    balance = bal[0] if bal else 0.0
+
+    row = cur.execute(
+        """
+        SELECT
+          SUM(CASE WHEN is_buy=1 THEN COALESCE(escrow,0) ELSE 0 END),
+          SUM(CASE WHEN is_buy=0 THEN price*volume_remain ELSE 0 END)
+        FROM char_orders WHERE state='open'
+        """
+    ).fetchone()
+    buy_escrow = row[0] or 0.0
+    sell_gross = row[1] or 0.0
+
+    inv = cur.execute(
+        """
+        SELECT a.type_id, SUM(a.quantity)
+        FROM assets a
+        GROUP BY a.type_id
+        """
+    ).fetchall()
+    qs_val = mk_val = 0.0
+    for tid, qty in inv:
+        tv = cur.execute(
+            "SELECT quicksell_bid, mark_ask FROM type_valuations WHERE type_id=?",
+            (tid,),
+        ).fetchone()
+        if not tv:
+            continue
+        bid, ask = tv
+        qs_val += (bid or 0.0) * qty
+        mk_val += (ask or bid or 0.0) * qty
+
+    sell_net = sell_gross * (1 - SALES_TAX - BROKER_SELL)
+
+    nav_quicksell = balance + buy_escrow + qs_val + sell_net
+    nav_mark = balance + buy_escrow + mk_val + sell_net
+
+    day = datetime.utcnow().date().isoformat()
+    con.execute(
+        """
+        INSERT OR REPLACE INTO portfolio_daily
+          (day, wallet_balance, buy_escrow, sell_gross, inventory_quicksell, inventory_mark, nav_quicksell, nav_mark)
+        VALUES (?,?,?,?,?,?,?,?)
+        """,
+        (day, balance, buy_escrow, sell_gross, qs_val, mk_val, nav_quicksell, nav_mark),
+    )
+    con.commit()
+    return {
+        "wallet_balance": balance,
+        "buy_escrow": buy_escrow,
+        "sell_gross": sell_gross,
+        "inventory_quicksell": qs_val,
+        "inventory_mark": mk_val,
+        "nav_quicksell": nav_quicksell,
+        "nav_mark": nav_mark,
+    }


### PR DESCRIPTION
## Summary
- build SQLite schema for wallets, orders, assets, and market snapshots
- add market and character sync utilities for Jita 4-4
- provide valuation and reporting helpers for P/L and NAV plots

## Testing
- `python -m py_compile $(find app -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ae4ab741448323af37a4cbfd04ef34