### PR TITLE
Add inventory cost tracking and item summary

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -144,6 +144,13 @@ CREATE TABLE IF NOT EXISTS realized_trades (
   broker_fee REAL NOT NULL,
   pnl REAL NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS inventory_cost_basis (
+  type_id INTEGER PRIMARY KEY,
+  remaining_qty INTEGER,
+  avg_cost REAL,
+  updated TEXT
+);
 """
 
 

--- a/app/pnl.py
+++ b/app/pnl.py
@@ -119,6 +119,19 @@ def pnl_fifo():
             """,
             row,
         )
+
+    con.execute("DELETE FROM inventory_cost_basis")
+    for type_id, lots in inventory.items():
+        total_qty = sum(q for q, _ in lots)
+        if total_qty > 0:
+            avg_cost = sum(q * p for q, p in lots) / total_qty
+            con.execute(
+                """
+                INSERT INTO inventory_cost_basis(type_id, remaining_qty, avg_cost, updated)
+                VALUES (?,?,?,?)
+                """,
+                (type_id, total_qty, avg_cost, datetime.utcnow().isoformat()),
+            )
     con.commit()
     con.close()
     return realized

--- a/app/run_character_sync.py
+++ b/app/run_character_sync.py
@@ -8,6 +8,7 @@ from .char_sync import (
     sync_assets,
 )
 from .valuation import refresh_type_valuations, compute_portfolio_snapshot
+from .pnl import pnl_fifo
 
 CHAR_ID = 0  # replace with your character id
 TOKEN = ""  # replace with access token
@@ -21,6 +22,7 @@ def main():
     sync_open_orders(con, CHAR_ID, TOKEN)
     sync_order_history(con, CHAR_ID, TOKEN)
     sync_assets(con, CHAR_ID, TOKEN)
+    pnl_fifo()
     cur = con.cursor()
     type_ids = set(
         t


### PR DESCRIPTION
## Summary
- Track average cost of remaining inventory in new `inventory_cost_basis` table
- Update FIFO P&L routine to populate inventory cost and hook into character sync
- Provide an `items_summary` report for last update, spreads, and unrealized P/L

## Testing
- `python -m py_compile app/db.py app/pnl.py app/run_character_sync.py app/reports.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae4be0cf648323af1a9c54ccaa27c9