### PR TITLE
docs: add startup instructions

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -1,0 +1,37 @@
+# Start Instructions
+
+This guide walks through setting up the VulnHawk Item Service and collecting data.
+
+## Prerequisites
+- Python 3.11 or newer
+- EVE Online developer application credentials and a character access token
+
+## Environment Setup
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install requests pandas matplotlib
+```
+
+## Database Initialization
+```bash
+python -c "from app.db import init_db; init_db()"
+```
+
+## Seed Region Types
+```bash
+python -c "from app.types_sync import seed_region_types; seed_region_types()"
+```
+
+## Fetch Market Trends and Order Snapshots
+```bash
+python -c "from app.trends import refresh_trends; refresh_trends()"
+python -c "from app.scheduler import fill_queue_from_trends, run_tick; fill_queue_from_trends(); run_tick()"
+```
+
+## Sync Character Data
+Set `CHAR_ID` and `TOKEN` in `app/run_character_sync.py` then run:
+```bash
+python -m app.run_character_sync
+```
+This synchronizes wallet, orders, assets and prints a portfolio snapshot.

--- a/README.md
+++ b/README.md
@@ -10,4 +10,34 @@ Features:
 - Trend calculations and scheduling helpers
 - Portfolio valuation and P/L plots
 
+## Getting Started
+
+1. Ensure Python 3.11+ is installed.
+2. Create a virtual environment and install dependencies:
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install requests pandas matplotlib
+   ```
+3. Initialize the database and seed market types:
+
+   ```bash
+   python -c "from app.db import init_db; init_db()"
+   python -c "from app.types_sync import seed_region_types; seed_region_types()"
+   ```
+4. (Optional) load trend data and fetch Jita order snapshots:
+
+   ```bash
+   python -c "from app.trends import refresh_trends; refresh_trends()"
+   python -c "from app.scheduler import fill_queue_from_trends, run_tick; fill_queue_from_trends(); run_tick()"
+   ```
+5. Set `CHAR_ID` and `TOKEN` in `app/run_character_sync.py` then run:
+
+   ```bash
+   python -m app.run_character_sync
+   ```
+
 Run `python -m py_compile $(git ls-files '*.py')` to verify syntax.
+
+See `INSTRUCTIONS.md` for more details.


### PR DESCRIPTION
## Summary
- add a Getting Started section to the README
- document detailed startup steps in a new INSTRUCTIONS.md

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ae4d9fa0648323bb9ffe448eea55f4