### PR TITLE
Load credentials from env file and drop deprecated wallet scopes

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -10,7 +10,7 @@ This guide walks through setting up the VulnHawk Item Service and collecting dat
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-pip install requests pandas matplotlib
+pip install requests pandas matplotlib python-dotenv
 ```
 
 ## Database Initialization
@@ -30,8 +30,8 @@ python -c "from app.scheduler import fill_queue_from_trends, run_tick; fill_queu
 ```
 
 ## Sync Character Data
-Set the environment variables `EVE_CLIENT_ID`, `EVE_CLIENT_SECRET` and
-`CHAR_ID`, then run:
+Provide the environment variables `EVE_CLIENT_ID`, `EVE_CLIENT_SECRET` and
+`CHAR_ID` (either export them or place them in a `.env` file), then run:
 ```bash
 python -m app.run_character_sync
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Features:
    ```bash
    python -m venv .venv
    source .venv/bin/activate
-   pip install requests pandas matplotlib
+   pip install requests pandas matplotlib python-dotenv
    ```
 3. Initialize the database and seed market types:
 
@@ -32,7 +32,7 @@ Features:
    python -c "from app.trends import refresh_trends; refresh_trends()"
    python -c "from app.scheduler import fill_queue_from_trends, run_tick; fill_queue_from_trends(); run_tick()"
    ```
-5. Set the following environment variables:
+5. Provide the following environment variables (either export them or place them in a `.env` file):
 
    - `EVE_CLIENT_ID` and `EVE_CLIENT_SECRET` – from your EVE developer application
    - `CHAR_ID` – your character's ID

--- a/app/auth.py
+++ b/app/auth.py
@@ -26,7 +26,10 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Dict
 
 import requests
+from dotenv import load_dotenv
 
+
+load_dotenv()
 
 TOKEN_FILE = "token.json"
 
@@ -38,8 +41,6 @@ CALLBACK_URL = os.environ.get("EVE_CALLBACK_URL", "http://localhost:5000/callbac
 SCOPES = " ".join(
     [
         "esi-wallet.read_character_wallet.v1",
-        "esi-wallet.read_character_journal.v1",
-        "esi-wallet.read_character_transactions.v1",
         "esi-markets.read_character_orders.v1",
         "esi-assets.read_assets.v1",
     ]


### PR DESCRIPTION
## Summary
- load EVE developer app credentials from a `.env` file using python-dotenv
- remove obsolete wallet journal/transaction scopes from character sync
- document python-dotenv dependency and `.env` usage in setup guides

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
import app.auth
print(app.auth.SCOPES)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68af298b455883238072de9b6c547b9b