### PR TITLE
Add verbose logging to sync processes

### DIFF
--- a/app/esi.py
+++ b/app/esi.py
@@ -1,10 +1,13 @@
 import time
+import logging
 import requests
 
 from .config import DATASOURCE
 
 BASE = "https://esi.evetech.net/latest"
 HEADERS = {"Accept": "application/json"}
+
+logger = logging.getLogger(__name__)
 
 
 def get(url, params=None, etag=None, token=None):
@@ -13,11 +16,14 @@ def get(url, params=None, etag=None, token=None):
         headers["If-None-Match"] = etag
     if token:
         headers["Authorization"] = f"Bearer {token}"
+    logger.info("GET %s params=%s", url, params)
     r = requests.get(url, params=params, headers=headers, timeout=30)
+    logger.info("response %s %s", r.status_code, r.headers.get("X-Pages"))
     if r.status_code == 304:
         return None, r.headers, 304
     if r.status_code >= 400:
         reset = int(r.headers.get("X-ESI-Error-Limit-Reset", "5"))
+        logger.warning("error %s, sleeping %s", r.status_code, reset)
         time.sleep(max(reset, 2))
         r.raise_for_status()
     return r.json(), r.headers, r.status_code
@@ -28,8 +34,10 @@ def paged(url, params=None, token=None):
     while True:
         p = dict(params or {})
         p["page"] = page
+        logger.info("Fetching page %s for %s", page, url)
         data, hdrs, _ = get(url, params=p, token=token)
         if not data:
+            logger.info("No data for page %s", page)
             break
         for row in data:
             yield row

--- a/app/run_character_sync.py
+++ b/app/run_character_sync.py
@@ -1,4 +1,5 @@
 import os
+import logging
 
 from .db import init_db, connect
 from .char_sync import (
@@ -13,12 +14,16 @@ from .valuation import refresh_type_valuations, compute_portfolio_snapshot
 from .pnl import pnl_fifo
 from .auth import get_token
 
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+
 CHAR_ID = int(os.getenv("CHAR_ID", "0"))
 
 
 def main():
     token = get_token()
     con = init_db()
+    logger = logging.getLogger(__name__)
+    logger.info("Starting character sync for %s", CHAR_ID)
     sync_wallet_balance(con, CHAR_ID, token)
     sync_wallet_journal(con, CHAR_ID, token)
     sync_wallet_transactions(con, CHAR_ID, token)


### PR DESCRIPTION
## Summary
- add INFO-level logging for all ESI requests and pagination
- log each character sync step and scheduler activity for easier debugging

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af310661d48323bfca52a7144c90d3