### PR TITLE
Add recommender groundwork and tracking tables

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -151,6 +151,29 @@ CREATE TABLE IF NOT EXISTS inventory_cost_basis (
   avg_cost REAL,
   updated TEXT
 );
+
+CREATE TABLE IF NOT EXISTS recommendations (
+  type_id INTEGER NOT NULL,
+  ts_utc TEXT NOT NULL,
+  net_pct REAL,
+  uplift_mom REAL,
+  daily_capacity REAL,
+  rationale_json TEXT,
+  PRIMARY KEY (type_id, ts_utc)
+);
+
+CREATE TABLE IF NOT EXISTS jobs_history (
+  name TEXT NOT NULL,
+  ts_utc TEXT NOT NULL,
+  ok INTEGER NOT NULL,
+  details_json TEXT,
+  PRIMARY KEY (name, ts_utc)
+);
+
+CREATE TABLE IF NOT EXISTS app_settings (
+  key TEXT PRIMARY KEY,
+  value TEXT
+);
 """
 
 

--- a/app/recommender.py
+++ b/app/recommender.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+import json
+from .db import connect
+from .market import evaluate_type
+from .config import MIN_DAILY_VOL
+
+
+def build_recommendations(limit=50):
+    """Populate the recommendations table with top candidates."""
+    con = connect()
+    try:
+        rows = con.execute(
+            "SELECT type_id FROM type_trends WHERE vol_30d_avg >= ? ORDER BY mom_pct DESC LIMIT ?",
+            (MIN_DAILY_VOL, limit),
+        ).fetchall()
+        now = datetime.utcnow().isoformat()
+        results = []
+        for (type_id,) in rows:
+            rec = evaluate_type(type_id)
+            if not rec:
+                continue
+            con.execute(
+                """
+                INSERT OR REPLACE INTO recommendations
+                (type_id, ts_utc, net_pct, uplift_mom, daily_capacity, rationale_json)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    rec["type_id"],
+                    now,
+                    rec["net_spread_pct"],
+                    rec["uplift_mom"],
+                    rec["daily_isk_capacity"],
+                    json.dumps(rec),
+                ),
+            )
+            results.append(rec)
+        con.commit()
+        return results
+    finally:
+        con.close()


### PR DESCRIPTION
## Summary
- add SQLite tables for recommendations, job history, and app settings
- implement basic recommendation builder that scans trend data and stores results

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af48962918832385e5468e1952fce7