### PR TITLE
Add FastAPI service and DB-backed settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,21 @@ The first run opens a browser window to authorize and caches a refresh token in
 orders and assets while printing a portfolio snapshot.
 
 Run `python -m py_compile $(git ls-files '*.py')` to verify syntax.
+
+### Local API Service
+With the database initialized you can launch a small FastAPI service that exposes
+status, settings and job triggers.
+
+```bash
+pip install fastapi uvicorn
+uvicorn app.service:app --reload
+```
+
+The service provides endpoints such as:
+
+- `GET /status` – recent job history
+- `GET /settings` – current configuration with defaults
+- `PUT /settings` – update configuration values
+- `POST /jobs/recommendations/run` – rebuild recommendation table
+- `POST /jobs/scheduler_tick/run` – process due market snapshots
+

--- a/app/service.py
+++ b/app/service.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+from fastapi import FastAPI, HTTPException
+from .settings_service import get_settings, update_settings
+from .recommender import build_recommendations
+from .scheduler import run_tick
+from .db import connect
+
+app = FastAPI()
+
+
+@app.get("/status")
+def status():
+    """Return recent job history for health checks."""
+    con = connect()
+    try:
+        rows = con.execute(
+            "SELECT name, ts_utc, ok FROM jobs_history ORDER BY ts_utc DESC LIMIT 20"
+        ).fetchall()
+    finally:
+        con.close()
+    return {"jobs": [{"name": n, "ts_utc": t, "ok": bool(o)} for n, t, o in rows]}
+
+
+@app.get("/settings")
+def read_settings():
+    return get_settings()
+
+
+@app.put("/settings")
+def write_settings(settings: dict):
+    allowed = set(get_settings().keys())
+    for key in settings.keys():
+        if key not in allowed:
+            raise HTTPException(status_code=400, detail=f"Unknown setting {key}")
+    update_settings(settings)
+    return get_settings()
+
+
+@app.post("/jobs/{name}/run")
+def run_job(name: str):
+    if name == "recommendations":
+        recs = build_recommendations()
+        return {"count": len(recs)}
+    if name == "scheduler_tick":
+        run_tick()
+        return {"status": "ok"}
+    raise HTTPException(status_code=404, detail="Job not found")

--- a/app/settings_service.py
+++ b/app/settings_service.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+import json
+from typing import Any, Dict
+from .db import connect
+from . import config
+
+# Default settings derived from config.py constants
+DEFAULTS: Dict[str, Any] = {
+    "STATION_ID": config.STATION_ID,
+    "REGION_ID": config.REGION_ID,
+    "DATASOURCE": config.DATASOURCE,
+    "VENUE": config.VENUE,
+    "SALES_TAX": config.SALES_TAX,
+    "BROKER_BUY": config.BROKER_BUY,
+    "BROKER_SELL": config.BROKER_SELL,
+    "RELIST_HAIRCUT": config.RELIST_HAIRCUT,
+    "MOM_THRESHOLD": config.MOM_THRESHOLD,
+    "MIN_DAYS_TRADED": config.MIN_DAYS_TRADED,
+    "MIN_DAILY_VOL": config.MIN_DAILY_VOL,
+    "SPREAD_BUFFER": config.SPREAD_BUFFER,
+}
+
+
+def _coerce(key: str, value: str) -> Any:
+    """Coerce string values back to the type of the default."""
+    default = DEFAULTS.get(key)
+    if isinstance(default, bool):
+        return value.lower() in {"1", "true", "yes"}
+    if isinstance(default, int) and not isinstance(default, bool):
+        return int(value)
+    if isinstance(default, float):
+        return float(value)
+    return value
+
+
+def get_settings() -> Dict[str, Any]:
+    """Return current settings merged with defaults."""
+    con = connect()
+    try:
+        rows = con.execute("SELECT key, value FROM app_settings").fetchall()
+    finally:
+        con.close()
+    stored = {k: _coerce(k, v) for k, v in rows}
+    merged: Dict[str, Any] = {}
+    for key, default in DEFAULTS.items():
+        merged[key] = stored.get(key, default)
+    return merged
+
+
+def update_settings(updates: Dict[str, Any]) -> None:
+    """Persist settings into the database."""
+    con = connect()
+    try:
+        for key, value in updates.items():
+            if key not in DEFAULTS:
+                continue
+            con.execute(
+                """
+                INSERT INTO app_settings(key, value)
+                VALUES (?, ?)
+                ON CONFLICT(key) DO UPDATE SET value=excluded.value
+                """,
+                (key, json.dumps(value) if isinstance(value, (dict, list)) else str(value)),
+            )
+        con.commit()
+    finally:
+        con.close()


### PR DESCRIPTION
## Summary
- Store runtime configuration in the SQLite `app_settings` table with defaults from `config.py`
- Expose configuration and job triggers through a new FastAPI service
- Document how to launch the local API service

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af4ea4b5b883239f0398e65b2684b0