### PR TITLE
Add job history logging and status test

### DIFF
--- a/app/jobs.py
+++ b/app/jobs.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+from datetime import datetime
+import json
+from typing import Any, Optional
+from . import db
+
+
+def record_job(name: str, ok: bool, details: Optional[Any] = None) -> None:
+    """Record a job execution in the jobs_history table."""
+    con = db.connect()
+    try:
+        con.execute(
+            """
+            INSERT INTO jobs_history(name, ts_utc, ok, details_json)
+            VALUES (?, ?, ?, ?)
+            """,
+            (
+                name,
+                datetime.utcnow().isoformat(),
+                1 if ok else 0,
+                json.dumps(details) if details is not None else None,
+            ),
+        )
+        con.commit()
+    finally:
+        con.close()

--- a/app/recommender.py
+++ b/app/recommender.py
@@ -3,6 +3,7 @@ import json
 from .db import connect
 from .market import evaluate_type
 from .config import MIN_DAILY_VOL
+from .jobs import record_job
 
 
 def build_recommendations(limit=50):
@@ -36,6 +37,10 @@ def build_recommendations(limit=50):
             )
             results.append(rec)
         con.commit()
+        record_job("recommendations", True, {"count": len(results)})
         return results
+    except Exception as e:
+        record_job("recommendations", False, {"error": str(e)})
+        raise
     finally:
         con.close()

--- a/tests/test_service_status.py
+++ b/tests/test_service_status.py
@@ -1,0 +1,22 @@
+from fastapi.testclient import TestClient
+import sys
+from pathlib import Path
+
+# Ensure 'app' package importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app import service, db, jobs
+
+
+def test_status_returns_jobs(tmp_path, monkeypatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "test.sqlite3")
+    db.init_db()
+    jobs.record_job("sample", True, {"info": 1})
+
+    client = TestClient(service.app)
+    resp = client.get("/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["jobs"]) == 1
+    assert data["jobs"][0]["name"] == "sample"
+    assert data["jobs"][0]["ok"] is True


### PR DESCRIPTION
## Summary
- log job executions to `jobs_history` via new `record_job`
- capture scheduler and recommendation runs in job history
- add API test for `/status` reporting job history

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af50ae8ec8832382443c46bbf95a34