### PR TITLE
Add portfolio NAV endpoint

### DIFF
--- a/app/service.py
+++ b/app/service.py
@@ -4,6 +4,7 @@ from .settings_service import get_settings, update_settings
 from .recommender import build_recommendations
 from .scheduler import run_tick
 from .db import connect
+from .valuation import compute_portfolio_snapshot
 import json
 
 app = FastAPI()
@@ -71,6 +72,17 @@ def list_recommendations(limit: int = 50, min_net: float = 0.0, min_mom: float =
             }
         )
     return {"results": results}
+
+
+@app.get("/portfolio/nav")
+def portfolio_nav():
+    """Compute and return a portfolio NAV snapshot."""
+    con = connect()
+    try:
+        snapshot = compute_portfolio_snapshot(con)
+    finally:
+        con.close()
+    return snapshot
 
 
 @app.post("/jobs/{name}/run")

--- a/tests/test_service_portfolio_nav.py
+++ b/tests/test_service_portfolio_nav.py
@@ -1,0 +1,73 @@
+from fastapi.testclient import TestClient
+import sys
+from pathlib import Path
+
+# Ensure 'app' package importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app import service, db
+from app import config
+
+
+def _seed_portfolio(con):
+    # Wallet balance
+    con.execute(
+        "INSERT INTO wallet_snapshots(ts_utc, balance) VALUES('2024-01-01T00:00:00', 100.0)"
+    )
+    # Buy order with escrow 5
+    con.execute(
+        """
+        INSERT INTO char_orders(
+          order_id, is_buy, region_id, location_id, type_id, price,
+          volume_total, volume_remain, issued, duration, range,
+          min_volume, escrow, last_seen, state)
+        VALUES (1,1,10000002,60003760,1,10,1,1,'2024-01-01',30,'region',1,5,'2024-01-01','open')
+        """
+    )
+    # Sell order with price 20
+    con.execute(
+        """
+        INSERT INTO char_orders(
+          order_id, is_buy, region_id, location_id, type_id, price,
+          volume_total, volume_remain, issued, duration, range,
+          min_volume, escrow, last_seen, state)
+        VALUES (2,0,10000002,60003760,1,20,1,1,'2024-01-01',30,'region',1,0,'2024-01-01','open')
+        """
+    )
+    # Inventory asset: 2 units of type 1
+    con.execute(
+        """
+        INSERT INTO assets(item_id, type_id, quantity, is_singleton, location_id, location_type, location_flag, updated)
+        VALUES (1,1,2,0,60003760,'station','hangar','2024-01-01')
+        """
+    )
+    # Valuations for type 1
+    con.execute(
+        "INSERT INTO type_valuations(type_id, quicksell_bid, mark_ask, updated) VALUES (1,8,12,'2024-01-01')"
+    )
+    con.commit()
+
+
+def test_portfolio_nav_snapshot(tmp_path, monkeypatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "test.sqlite3")
+    db.init_db()
+    con = db.connect()
+    try:
+        _seed_portfolio(con)
+    finally:
+        con.close()
+
+    client = TestClient(service.app)
+    resp = client.get("/portfolio/nav")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # Expected calculations
+    sell_net = 20 * (1 - config.SALES_TAX - config.BROKER_SELL)
+    assert data["wallet_balance"] == 100.0
+    assert data["buy_escrow"] == 5.0
+    assert data["sell_gross"] == 20.0
+    assert data["inventory_quicksell"] == 16.0
+    assert data["inventory_mark"] == 24.0
+    assert data["nav_quicksell"] == 100.0 + 5.0 + 16.0 + sell_net
+    assert data["nav_mark"] == 100.0 + 5.0 + 24.0 + sell_net


### PR DESCRIPTION
## Summary
- expose GET /portfolio/nav endpoint returning a computed NAV snapshot
- test portfolio snapshot calculations against seeded data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af51cbb5208323b21a0d23e3cfb554