### PR TITLE
Add open orders API endpoint

### DIFF
--- a/app/service.py
+++ b/app/service.py
@@ -74,6 +74,51 @@ def list_recommendations(limit: int = 50, min_net: float = 0.0, min_mom: float =
     return {"results": results}
 
 
+@app.get("/orders/open")
+def list_open_orders(limit: int = 100):
+    """Return open character orders with fill percentage."""
+    con = connect()
+    try:
+        rows = con.execute(
+            """
+            SELECT order_id, is_buy, type_id, price, volume_total, volume_remain, issued, escrow
+            FROM char_orders
+            WHERE state='open'
+            ORDER BY issued DESC
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+    finally:
+        con.close()
+    orders = []
+    for (
+        order_id,
+        is_buy,
+        type_id,
+        price,
+        vol_total,
+        vol_remain,
+        issued,
+        escrow,
+    ) in rows:
+        fill_pct = (vol_total - vol_remain) / vol_total if vol_total else 0.0
+        orders.append(
+            {
+                "order_id": order_id,
+                "is_buy": bool(is_buy),
+                "type_id": type_id,
+                "price": price,
+                "volume_total": vol_total,
+                "volume_remain": vol_remain,
+                "fill_pct": fill_pct,
+                "issued": issued,
+                "escrow": escrow,
+            }
+        )
+    return {"orders": orders}
+
+
 @app.get("/portfolio/nav")
 def portfolio_nav():
     """Compute and return a portfolio NAV snapshot."""

--- a/tests/test_service_orders.py
+++ b/tests/test_service_orders.py
@@ -1,0 +1,43 @@
+from fastapi.testclient import TestClient
+import sys
+from pathlib import Path
+
+# Ensure 'app' package importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app import service, db
+
+
+def _seed_orders(con):
+    con.execute(
+        """
+        INSERT INTO char_orders(
+          order_id, is_buy, region_id, location_id, type_id, price,
+          volume_total, volume_remain, issued, duration, range,
+          min_volume, escrow, last_seen, state)
+        VALUES
+          (1,1,10000002,60003760,1,10,10,5,'2024-01-01',30,'region',1,100,'2024-01-01','open'),
+          (2,0,10000002,60003760,1,20,5,5,'2024-01-01',30,'region',1,0,'2024-01-01','closed')
+        """
+    )
+    con.commit()
+
+
+def test_list_open_orders(tmp_path, monkeypatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "test.sqlite3")
+    db.init_db()
+    con = db.connect()
+    try:
+        _seed_orders(con)
+    finally:
+        con.close()
+
+    client = TestClient(service.app)
+    resp = client.get("/orders/open")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["orders"]) == 1
+    order = data["orders"][0]
+    assert order["order_id"] == 1
+    assert order["is_buy"] is True
+    assert order["fill_pct"] == 0.5


### PR DESCRIPTION
## Summary
- expose `/orders/open` endpoint returning open orders with fill percentages
- test the new endpoint

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af52f8686c8323b21c167fe832205e