### PR TITLE
feat(ui): add recommendations page

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,16 +1,18 @@
 import { Link, Routes, Route } from 'react-router-dom';
 import Dashboard from './pages/Dashboard';
 import Settings from './pages/Settings';
+import Recommendations from './pages/Recommendations';
 import './App.css';
 
 export default function App() {
   return (
     <>
       <nav>
-        <Link to="/">Dashboard</Link> | <Link to="/settings">Settings</Link>
+        <Link to="/">Dashboard</Link> | <Link to="/recommendations">Recommendations</Link> | <Link to="/settings">Settings</Link>
       </nav>
       <Routes>
         <Route path="/" element={<Dashboard />} />
+        <Route path="/recommendations" element={<Recommendations />} />
         <Route path="/settings" element={<Settings />} />
       </Routes>
     </>

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -12,7 +12,7 @@ export async function getSettings() {
   return res.json();
 }
 
-export async function updateSettings(settings: Record<string, any>) {
+export async function updateSettings(settings: Record<string, unknown>) {
   const res = await fetch(`${API_BASE}/settings`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
@@ -25,5 +25,16 @@ export async function updateSettings(settings: Record<string, any>) {
 export async function runJob(name: string) {
   const res = await fetch(`${API_BASE}/jobs/${name}/run`, { method: 'POST' });
   if (!res.ok) throw new Error('Failed to run job');
+  return res.json();
+}
+
+export async function getRecommendations(limit = 50, minNet = 0, minMom = 0) {
+  const params = new URLSearchParams({
+    limit: String(limit),
+    min_net: String(minNet),
+    min_mom: String(minMom),
+  });
+  const res = await fetch(`${API_BASE}/recommendations?${params.toString()}`);
+  if (!res.ok) throw new Error('Failed to fetch recommendations');
   return res.json();
 }

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -16,8 +16,12 @@ export default function Dashboard() {
       const data = await getStatus();
       setJobs(data.jobs || []);
       setError('');
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        setError(e.message);
+      } else {
+        setError(String(e));
+      }
     }
   }
 

--- a/ui/src/pages/Recommendations.tsx
+++ b/ui/src/pages/Recommendations.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import { getRecommendations } from '../api';
+
+interface Rec {
+  type_id: number;
+  ts_utc: string;
+  net_pct: number;
+  uplift_mom: number;
+  daily_capacity: number;
+}
+
+export default function Recommendations() {
+  const [recs, setRecs] = useState<Rec[]>([]);
+  const [minNet, setMinNet] = useState(0);
+  const [minMom, setMinMom] = useState(0);
+  const [error, setError] = useState('');
+
+  async function refresh() {
+    try {
+      const data = await getRecommendations(50, minNet, minMom);
+      setRecs(data.results || []);
+      setError('');
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        setError(e.message);
+      } else {
+        setError(String(e));
+      }
+    }
+  }
+
+  useEffect(() => {
+    refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div>
+      <h2>Recommendations</h2>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <div>
+        <label>
+          Min Net %: <input type="number" value={minNet} onChange={e => setMinNet(Number(e.target.value))} />
+        </label>
+        <label style={{ marginLeft: '1em' }}>
+          Min MoM %: <input type="number" value={minMom} onChange={e => setMinMom(Number(e.target.value))} />
+        </label>
+        <button style={{ marginLeft: '1em' }} onClick={refresh}>Refresh</button>
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>Type ID</th>
+            <th>Net %</th>
+            <th>MoM %</th>
+            <th>Daily ISK</th>
+          </tr>
+        </thead>
+        <tbody>
+          {recs.map(r => (
+            <tr key={r.type_id}>
+              <td>{r.type_id}</td>
+              <td>{(r.net_pct * 100).toFixed(2)}</td>
+              <td>{(r.uplift_mom * 100).toFixed(2)}</td>
+              <td>{Math.round(r.daily_capacity)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/ui/src/pages/Settings.tsx
+++ b/ui/src/pages/Settings.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { getSettings, updateSettings } from '../api';
 
 export default function Settings() {
-  const [settings, setSettings] = useState<Record<string, any>>({});
+  const [settings, setSettings] = useState<Record<string, unknown>>({});
   const [error, setError] = useState('');
 
   useEffect(() => {
@@ -17,8 +17,12 @@ export default function Settings() {
     try {
       await updateSettings(settings);
       alert('Saved');
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        setError(e.message);
+      } else {
+        setError(String(e));
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- add API helper for fetching recommendations
- expose new Recommendations page and navigation
- improve error handling and typing in dashboard and settings

## Testing
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af6131f9ec83239a20bcb2b73fcf0f