### PR TITLE
feat(ui): add orders page

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -2,17 +2,22 @@ import { Link, Routes, Route } from 'react-router-dom';
 import Dashboard from './pages/Dashboard';
 import Settings from './pages/Settings';
 import Recommendations from './pages/Recommendations';
+import Orders from './pages/Orders';
 import './App.css';
 
 export default function App() {
   return (
     <>
       <nav>
-        <Link to="/">Dashboard</Link> | <Link to="/recommendations">Recommendations</Link> | <Link to="/settings">Settings</Link>
+        <Link to="/">Dashboard</Link> |
+        <Link to="/recommendations">Recommendations</Link> |
+        <Link to="/orders">Orders</Link> |
+        <Link to="/settings">Settings</Link>
       </nav>
       <Routes>
         <Route path="/" element={<Dashboard />} />
         <Route path="/recommendations" element={<Recommendations />} />
+        <Route path="/orders" element={<Orders />} />
         <Route path="/settings" element={<Settings />} />
       </Routes>
     </>

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -38,3 +38,15 @@ export async function getRecommendations(limit = 50, minNet = 0, minMom = 0) {
   if (!res.ok) throw new Error('Failed to fetch recommendations');
   return res.json();
 }
+
+export async function getOpenOrders(limit = 100) {
+  const res = await fetch(`${API_BASE}/orders/open?limit=${limit}`);
+  if (!res.ok) throw new Error('Failed to fetch open orders');
+  return res.json();
+}
+
+export async function getOrderHistory(limit = 100) {
+  const res = await fetch(`${API_BASE}/orders/history?limit=${limit}`);
+  if (!res.ok) throw new Error('Failed to fetch order history');
+  return res.json();
+}

--- a/ui/src/pages/Orders.tsx
+++ b/ui/src/pages/Orders.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react';
+import { getOpenOrders, getOrderHistory } from '../api';
+
+interface Order {
+  order_id: number;
+  is_buy: boolean;
+  type_id: number;
+  price: number;
+  volume_total: number;
+  volume_remain: number;
+  fill_pct: number;
+  issued: string;
+  escrow: number;
+  state?: string;
+}
+
+export default function Orders() {
+  const [openOrders, setOpenOrders] = useState<Order[]>([]);
+  const [history, setHistory] = useState<Order[]>([]);
+  const [error, setError] = useState('');
+
+  async function refresh() {
+    try {
+      const open = await getOpenOrders();
+      const hist = await getOrderHistory();
+      setOpenOrders(open.orders || []);
+      setHistory(hist.orders || []);
+      setError('');
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        setError(e.message);
+      } else {
+        setError(String(e));
+      }
+    }
+  }
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  return (
+    <div>
+      <h2>Orders</h2>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <button onClick={refresh}>Refresh</button>
+
+      <h3>Open Orders</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Order ID</th>
+            <th>Type ID</th>
+            <th>Price</th>
+            <th>Filled %</th>
+            <th>Escrow</th>
+          </tr>
+        </thead>
+        <tbody>
+          {openOrders.map(o => (
+            <tr key={o.order_id}>
+              <td>{o.order_id}</td>
+              <td>{o.type_id}</td>
+              <td>{o.price.toFixed(2)}</td>
+              <td>{(o.fill_pct * 100).toFixed(1)}</td>
+              <td>{o.escrow.toFixed(2)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h3>Recent History</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Order ID</th>
+            <th>Type ID</th>
+            <th>Price</th>
+            <th>Filled %</th>
+            <th>State</th>
+          </tr>
+        </thead>
+        <tbody>
+          {history.map(o => (
+            <tr key={o.order_id}>
+              <td>{o.order_id}</td>
+              <td>{o.type_id}</td>
+              <td>{o.price.toFixed(2)}</td>
+              <td>{(o.fill_pct * 100).toFixed(1)}</td>
+              <td>{o.state}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add orders tab to fetch and list open orders and recent order history
- include API helpers for orders endpoints
- wire orders page into navigation

## Testing
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af627853348323804c87adc27ab595