### PR TITLE
Add portfolio NAV page to UI

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -3,6 +3,7 @@ import Dashboard from './pages/Dashboard';
 import Settings from './pages/Settings';
 import Recommendations from './pages/Recommendations';
 import Orders from './pages/Orders';
+import Portfolio from './pages/Portfolio';
 import './App.css';
 
 export default function App() {
@@ -11,12 +12,14 @@ export default function App() {
       <nav>
         <Link to="/">Dashboard</Link> |
         <Link to="/recommendations">Recommendations</Link> |
+        <Link to="/portfolio">Portfolio</Link> |
         <Link to="/orders">Orders</Link> |
         <Link to="/settings">Settings</Link>
       </nav>
       <Routes>
         <Route path="/" element={<Dashboard />} />
         <Route path="/recommendations" element={<Recommendations />} />
+        <Route path="/portfolio" element={<Portfolio />} />
         <Route path="/orders" element={<Orders />} />
         <Route path="/settings" element={<Settings />} />
       </Routes>

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -50,3 +50,9 @@ export async function getOrderHistory(limit = 100) {
   if (!res.ok) throw new Error('Failed to fetch order history');
   return res.json();
 }
+
+export async function getPortfolioNav() {
+  const res = await fetch(`${API_BASE}/portfolio/nav`);
+  if (!res.ok) throw new Error('Failed to fetch portfolio NAV');
+  return res.json();
+}

--- a/ui/src/pages/Portfolio.tsx
+++ b/ui/src/pages/Portfolio.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import { getPortfolioNav } from '../api';
+
+interface Snapshot {
+  wallet_balance: number;
+  buy_escrow: number;
+  sell_gross: number;
+  inventory_quicksell: number;
+  inventory_mark: number;
+  nav_quicksell: number;
+  nav_mark: number;
+}
+
+export default function Portfolio() {
+  const [snap, setSnap] = useState<Snapshot | null>(null);
+  const [error, setError] = useState('');
+
+  async function refresh() {
+    try {
+      const data = await getPortfolioNav();
+      setSnap(data);
+      setError('');
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        setError(e.message);
+      } else {
+        setError(String(e));
+      }
+    }
+  }
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  return (
+    <div>
+      <h2>Portfolio</h2>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <button onClick={refresh}>Refresh</button>
+      {snap && (
+        <table>
+          <tbody>
+            <tr><td>Wallet Balance</td><td>{snap.wallet_balance.toFixed(2)}</td></tr>
+            <tr><td>Buy Escrow</td><td>{snap.buy_escrow.toFixed(2)}</td></tr>
+            <tr><td>Sell Gross</td><td>{snap.sell_gross.toFixed(2)}</td></tr>
+            <tr><td>Inventory (Quicksell)</td><td>{snap.inventory_quicksell.toFixed(2)}</td></tr>
+            <tr><td>Inventory (Mark)</td><td>{snap.inventory_mark.toFixed(2)}</td></tr>
+            <tr><td>NAV (Quicksell)</td><td>{snap.nav_quicksell.toFixed(2)}</td></tr>
+            <tr><td>NAV (Mark)</td><td>{snap.nav_mark.toFixed(2)}</td></tr>
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add API helper to load portfolio NAV data
- implement Portfolio page rendering wallet, escrow, inventory and NAV figures
- link the new page into main navigation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af63ac224c8323b29b0fc3f8a0811f