### PR TITLE
Expose ESI error limit in status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ eve_trader.sqlite3
 __pycache__/
 *.pyc
 token.json
+ui/node_modules/
+ui/dist/

--- a/app/esi.py
+++ b/app/esi.py
@@ -9,6 +9,10 @@ HEADERS = {"Accept": "application/json"}
 
 logger = logging.getLogger(__name__)
 
+# Track ESI error limit headers for observability
+ERROR_LIMIT_REMAIN = 100
+ERROR_LIMIT_RESET = 0
+
 
 def get(url, params=None, etag=None, token=None):
     headers = dict(HEADERS)
@@ -18,11 +22,16 @@ def get(url, params=None, etag=None, token=None):
         headers["Authorization"] = f"Bearer {token}"
     logger.info("GET %s params=%s", url, params)
     r = requests.get(url, params=params, headers=headers, timeout=30)
-    logger.info("response %s %s", r.status_code, r.headers.get("X-Pages"))
+    global ERROR_LIMIT_REMAIN, ERROR_LIMIT_RESET
+    ERROR_LIMIT_REMAIN = int(r.headers.get("X-ESI-Error-Limit-Remain", ERROR_LIMIT_REMAIN))
+    ERROR_LIMIT_RESET = int(r.headers.get("X-ESI-Error-Limit-Reset", ERROR_LIMIT_RESET))
+    logger.info(
+        "response %s %s", r.status_code, r.headers.get("X-Pages")
+    )
     if r.status_code == 304:
         return None, r.headers, 304
     if r.status_code >= 400:
-        reset = int(r.headers.get("X-ESI-Error-Limit-Reset", "5"))
+        reset = ERROR_LIMIT_RESET or 5
         logger.warning("error %s, sleeping %s", r.status_code, reset)
         time.sleep(max(reset, 2))
         r.raise_for_status()
@@ -45,3 +54,11 @@ def paged(url, params=None, token=None):
         if page >= pages:
             break
         page += 1
+
+
+def get_error_limit_status():
+    """Return current cached ESI error limit information."""
+    return {
+        "error_limit_remain": ERROR_LIMIT_REMAIN,
+        "error_limit_reset": ERROR_LIMIT_RESET,
+    }

--- a/app/service.py
+++ b/app/service.py
@@ -5,6 +5,7 @@ from .recommender import build_recommendations
 from .scheduler import run_tick
 from .db import connect
 from .valuation import compute_portfolio_snapshot
+from .esi import get_error_limit_status
 import json
 
 app = FastAPI()
@@ -20,7 +21,10 @@ def status():
         ).fetchall()
     finally:
         con.close()
-    return {"jobs": [{"name": n, "ts_utc": t, "ok": bool(o)} for n, t, o in rows]}
+    return {
+        "jobs": [{"name": n, "ts_utc": t, "ok": bool(o)} for n, t, o in rows],
+        "esi": get_error_limit_status(),
+    }
 
 
 @app.get("/settings")

--- a/tests/test_service_status.py
+++ b/tests/test_service_status.py
@@ -5,13 +5,15 @@ from pathlib import Path
 # Ensure 'app' package importable
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from app import service, db, jobs
+from app import service, db, jobs, esi
 
 
 def test_status_returns_jobs(tmp_path, monkeypatch):
     monkeypatch.setattr(db, "DB_PATH", tmp_path / "test.sqlite3")
     db.init_db()
     jobs.record_job("sample", True, {"info": 1})
+    esi.ERROR_LIMIT_REMAIN = 88
+    esi.ERROR_LIMIT_RESET = 17
 
     client = TestClient(service.app)
     resp = client.get("/status")
@@ -20,3 +22,5 @@ def test_status_returns_jobs(tmp_path, monkeypatch):
     assert len(data["jobs"]) == 1
     assert data["jobs"][0]["name"] == "sample"
     assert data["jobs"][0]["ok"] is True
+    assert data["esi"]["error_limit_remain"] == 88
+    assert data["esi"]["error_limit_reset"] == 17

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1,6 +1,11 @@
 export const API_BASE = 'http://localhost:8000';
 
-export async function getStatus() {
+export interface StatusResp {
+  jobs: { name: string; ts_utc: string; ok: boolean }[];
+  esi: { error_limit_remain: number; error_limit_reset: number };
+}
+
+export async function getStatus(): Promise<StatusResp> {
   const res = await fetch(`${API_BASE}/status`);
   if (!res.ok) throw new Error('Failed to fetch status');
   return res.json();

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { getStatus, runJob } from '../api';
+import { getStatus, runJob, StatusResp } from '../api';
 
 interface JobRec {
   name: string;
@@ -9,12 +9,14 @@ interface JobRec {
 
 export default function Dashboard() {
   const [jobs, setJobs] = useState<JobRec[]>([]);
+  const [esi, setEsi] = useState<StatusResp['esi'] | null>(null);
   const [error, setError] = useState<string>('');
 
   async function refresh() {
     try {
       const data = await getStatus();
       setJobs(data.jobs || []);
+      setEsi(data.esi);
       setError('');
     } catch (e: unknown) {
       if (e instanceof Error) {
@@ -33,6 +35,9 @@ export default function Dashboard() {
     <div>
       <h2>Dashboard</h2>
       {error && <p style={{ color: 'red' }}>{error}</p>}
+      {esi && (
+        <p>ESI Error Limit: {esi.error_limit_remain} (reset {esi.error_limit_reset}s)</p>
+      )}
       <button onClick={() => { runJob('scheduler_tick').then(refresh); }}>Run Scheduler</button>
       <button onClick={() => { runJob('recommendations').then(refresh); }}>Build Recommendations</button>
       <h3>Recent Jobs</h3>


### PR DESCRIPTION
## Summary
- Track ESI error limit headers during API calls
- Surface ESI health in /status endpoint and dashboard
- Ignore UI build artifacts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af652794b88323bf2be10e5f0db70e