### PR TITLE
Add auth endpoints and UI login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,4 +70,6 @@ The service provides endpoints such as:
 - `PUT /settings` – update configuration values
 - `POST /jobs/recommendations/run` – rebuild recommendation table
 - `POST /jobs/scheduler_tick/run` – process due market snapshots
+- `GET /auth/status` – check whether SSO token is cached
+- `POST /auth/connect` – initiate the EVE SSO flow
 

--- a/app/auth.py
+++ b/app/auth.py
@@ -155,3 +155,14 @@ def get_token() -> str:
         raise RuntimeError("Authorization failed; no code received")
     return _exchange_code(code)
 
+
+def token_status() -> dict:
+    """Return whether a cached token exists and its expiry timestamp."""
+    tokens = _load_tokens()
+    if not tokens:
+        return {"has_token": False, "expires_at": 0}
+    return {
+        "has_token": True,
+        "expires_at": tokens.get("expires_at", 0),
+    }
+

--- a/app/service.py
+++ b/app/service.py
@@ -6,6 +6,7 @@ from .scheduler import run_tick
 from .db import connect
 from .valuation import compute_portfolio_snapshot
 from .esi import get_error_limit_status
+from .auth import get_token, token_status
 import json
 
 app = FastAPI()
@@ -25,6 +26,19 @@ def status():
         "jobs": [{"name": n, "ts_utc": t, "ok": bool(o)} for n, t, o in rows],
         "esi": get_error_limit_status(),
     }
+
+
+@app.get("/auth/status")
+def auth_status():
+    """Report whether a cached SSO token is available."""
+    return token_status()
+
+
+@app.post("/auth/connect")
+def auth_connect():
+    """Initiate the SSO flow to obtain a token if missing or expired."""
+    get_token()
+    return {"status": "ok"}
 
 
 @app.get("/settings")

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,12 +1,22 @@
-import { Link, Routes, Route } from 'react-router-dom';
+import { Link, Routes, Route, useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
 import Dashboard from './pages/Dashboard';
 import Settings from './pages/Settings';
 import Recommendations from './pages/Recommendations';
 import Orders from './pages/Orders';
 import Portfolio from './pages/Portfolio';
+import Login from './pages/Login';
+import { getAuthStatus } from './api';
 import './App.css';
 
 export default function App() {
+  const navigate = useNavigate();
+  useEffect(() => {
+    getAuthStatus().then(s => {
+      if (!s.has_token) navigate('/login');
+    }).catch(() => navigate('/login'));
+  }, [navigate]);
+
   return (
     <>
       <nav>
@@ -22,6 +32,7 @@ export default function App() {
         <Route path="/portfolio" element={<Portfolio />} />
         <Route path="/orders" element={<Orders />} />
         <Route path="/settings" element={<Settings />} />
+        <Route path="/login" element={<Login />} />
       </Routes>
     </>
   );

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -61,3 +61,20 @@ export async function getPortfolioNav() {
   if (!res.ok) throw new Error('Failed to fetch portfolio NAV');
   return res.json();
 }
+
+export interface AuthStatus {
+  has_token: boolean;
+  expires_at: number;
+}
+
+export async function getAuthStatus(): Promise<AuthStatus> {
+  const res = await fetch(`${API_BASE}/auth/status`);
+  if (!res.ok) throw new Error('Failed to fetch auth status');
+  return res.json();
+}
+
+export async function connectAuth() {
+  const res = await fetch(`${API_BASE}/auth/connect`, { method: 'POST' });
+  if (!res.ok) throw new Error('Failed to start auth');
+  return res.json();
+}

--- a/ui/src/pages/Login.tsx
+++ b/ui/src/pages/Login.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getAuthStatus, connectAuth, AuthStatus } from '../api';
+
+export default function Login() {
+  const [status, setStatus] = useState<AuthStatus | null>(null);
+  const [error, setError] = useState('');
+  const navigate = useNavigate();
+
+  async function refresh() {
+    try {
+      const data = await getAuthStatus();
+      setStatus(data);
+      if (data.has_token) {
+        navigate('/');
+      }
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        setError(e.message);
+      } else {
+        setError(String(e));
+      }
+    }
+  }
+
+  useEffect(() => {
+    refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function connect() {
+    try {
+      await connectAuth();
+      await refresh();
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        setError(e.message);
+      } else {
+        setError(String(e));
+      }
+    }
+  }
+
+  return (
+    <div>
+      <h2>Connect EVE Account</h2>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      {!status?.has_token && (
+        <button onClick={connect}>Connect</button>
+      )}
+      {status?.has_token && <p>Connected. Redirecting...</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- expose auth status and connect endpoints in FastAPI service
- add login page and auth check in Tauri React UI
- document new auth endpoints

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `cd ui && npm install`
- `cd ui && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af68cc29c483238b3fc121b2885236