### PR TITLE
Add type name mapping and recommendation explain modal

### DIFF
--- a/app/service.py
+++ b/app/service.py
@@ -56,6 +56,32 @@ def write_settings(settings: dict):
     return get_settings()
 
 
+@app.get("/types/map")
+def types_map(ids: str | None = None):
+    """Return mapping of type_ids to names.
+
+    If ``ids`` query parameter is provided, it should be a comma-separated
+    list of type IDs to look up. Otherwise all known types are returned.
+    """
+    con = connect()
+    try:
+        if ids:
+            id_list = [int(i) for i in ids.split(",") if i]
+            if id_list:
+                placeholders = ",".join("?" for _ in id_list)
+                rows = con.execute(
+                    f"SELECT type_id, name FROM types WHERE type_id IN ({placeholders})",
+                    id_list,
+                ).fetchall()
+            else:
+                rows = []
+        else:
+            rows = con.execute("SELECT type_id, name FROM types").fetchall()
+    finally:
+        con.close()
+    return {tid: name for tid, name in rows}
+
+
 @app.get("/recommendations")
 def list_recommendations(limit: int = 50, min_net: float = 0.0, min_mom: float = 0.0):
     """Return recent recommendations filtered by net spread and MoM uplift."""

--- a/tests/test_service_types_map.py
+++ b/tests/test_service_types_map.py
@@ -1,0 +1,35 @@
+from fastapi.testclient import TestClient
+import sys
+from pathlib import Path
+
+# Ensure 'app' package is importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app import service, db
+
+
+def _seed_types(con):
+    con.execute(
+        """
+        INSERT INTO types(type_id, name, group_id)
+        VALUES (1, 'Foo', 10), (2, 'Bar', 20)
+        """
+    )
+    con.commit()
+
+
+def test_types_map(tmp_path, monkeypatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "test.sqlite3")
+    db.init_db()
+    con = db.connect()
+    try:
+        _seed_types(con)
+    finally:
+        con.close()
+
+    client = TestClient(service.app)
+    resp = client.get("/types/map", params={"ids": "1,2"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["1"] == "Foo"
+    assert data["2"] == "Bar"

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -62,6 +62,18 @@ export async function getPortfolioNav() {
   return res.json();
 }
 
+export async function getTypeNames(ids: number[]): Promise<Record<number, string>> {
+  const params = ids.length ? `?ids=${ids.join(',')}` : '';
+  const res = await fetch(`${API_BASE}/types/map${params}`);
+  if (!res.ok) throw new Error('Failed to fetch type names');
+  const data = await res.json();
+  const result: Record<number, string> = {};
+  for (const [k, v] of Object.entries(data)) {
+    result[Number(k)] = v as string;
+  }
+  return result;
+}
+
 export interface AuthStatus {
   has_token: boolean;
   expires_at: number;


### PR DESCRIPTION
## Summary
- add `/types/map` API endpoint to look up item names
- show item names on Orders and Recommendations pages via new `getTypeNames` API helper
- add basic Explain modal on Recommendations to display rationale details
- cover types map endpoint with tests

## Testing
- `pytest -q`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af6dac0e44832380fd0445b00c6b18