### PR TITLE
Add loading spinners and error banners across UI

### DIFF
--- a/ui/src/ErrorBanner.tsx
+++ b/ui/src/ErrorBanner.tsx
@@ -1,0 +1,4 @@
+export default function ErrorBanner({ message }: { message: string }) {
+  if (!message) return null;
+  return <div className="error-banner">{message}</div>;
+}

--- a/ui/src/Spinner.tsx
+++ b/ui/src/Spinner.tsx
@@ -1,0 +1,3 @@
+export default function Spinner() {
+  return <div className="spinner" role="status" aria-label="loading" />;
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -66,3 +66,24 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 }
+
+.spinner {
+  border: 4px solid #ccc;
+  border-top-color: #333;
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  animation: spin 1s linear infinite;
+  margin: 1em auto;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.error-banner {
+  color: red;
+  margin: 1em 0;
+}

--- a/ui/src/pages/Login.tsx
+++ b/ui/src/pages/Login.tsx
@@ -1,25 +1,32 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { getAuthStatus, connectAuth, AuthStatus } from '../api';
+import { getAuthStatus, connectAuth, type AuthStatus } from '../api';
+import Spinner from '../Spinner';
+import ErrorBanner from '../ErrorBanner';
 
 export default function Login() {
   const [status, setStatus] = useState<AuthStatus | null>(null);
   const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
 
   async function refresh() {
+    setLoading(true);
     try {
       const data = await getAuthStatus();
       setStatus(data);
       if (data.has_token) {
         navigate('/');
       }
+      setError('');
     } catch (e: unknown) {
       if (e instanceof Error) {
         setError(e.message);
       } else {
         setError(String(e));
       }
+    } finally {
+      setLoading(false);
     }
   }
 
@@ -29,6 +36,7 @@ export default function Login() {
   }, []);
 
   async function connect() {
+    setLoading(true);
     try {
       await connectAuth();
       await refresh();
@@ -38,15 +46,18 @@ export default function Login() {
       } else {
         setError(String(e));
       }
+    } finally {
+      setLoading(false);
     }
   }
 
   return (
     <div>
       <h2>Connect EVE Account</h2>
-      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <ErrorBanner message={error} />
+      {loading && <Spinner />}
       {!status?.has_token && (
-        <button onClick={connect}>Connect</button>
+        <button onClick={connect} disabled={loading}>Connect</button>
       )}
       {status?.has_token && <p>Connected. Redirecting...</p>}
     </div>

--- a/ui/src/pages/Orders.tsx
+++ b/ui/src/pages/Orders.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 import { getOpenOrders, getOrderHistory, getTypeNames } from '../api';
+import Spinner from '../Spinner';
+import ErrorBanner from '../ErrorBanner';
 
 interface Order {
   order_id: number;
@@ -18,9 +20,11 @@ export default function Orders() {
   const [openOrders, setOpenOrders] = useState<Order[]>([]);
   const [history, setHistory] = useState<Order[]>([]);
   const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
   const [typeNames, setTypeNames] = useState<Record<number, string>>({});
 
   async function refresh() {
+    setLoading(true);
     try {
       const open = await getOpenOrders();
       const hist = await getOrderHistory();
@@ -40,6 +44,8 @@ export default function Orders() {
       } else {
         setError(String(e));
       }
+    } finally {
+      setLoading(false);
     }
   }
 
@@ -50,8 +56,9 @@ export default function Orders() {
   return (
     <div>
       <h2>Orders</h2>
-      {error && <p style={{ color: 'red' }}>{error}</p>}
-      <button onClick={refresh}>Refresh</button>
+      <ErrorBanner message={error} />
+      {loading && <Spinner />}
+      <button onClick={refresh} disabled={loading}>Refresh</button>
 
       <h3>Open Orders</h3>
       <table>

--- a/ui/src/pages/Portfolio.tsx
+++ b/ui/src/pages/Portfolio.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 import { getPortfolioNav } from '../api';
+import Spinner from '../Spinner';
+import ErrorBanner from '../ErrorBanner';
 
 interface Snapshot {
   wallet_balance: number;
@@ -14,8 +16,10 @@ interface Snapshot {
 export default function Portfolio() {
   const [snap, setSnap] = useState<Snapshot | null>(null);
   const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
 
   async function refresh() {
+    setLoading(true);
     try {
       const data = await getPortfolioNav();
       setSnap(data);
@@ -26,6 +30,8 @@ export default function Portfolio() {
       } else {
         setError(String(e));
       }
+    } finally {
+      setLoading(false);
     }
   }
 
@@ -36,8 +42,9 @@ export default function Portfolio() {
   return (
     <div>
       <h2>Portfolio</h2>
-      {error && <p style={{ color: 'red' }}>{error}</p>}
-      <button onClick={refresh}>Refresh</button>
+      <ErrorBanner message={error} />
+      {loading && <Spinner />}
+      <button onClick={refresh} disabled={loading}>Refresh</button>
       {snap && (
         <table>
           <tbody>


### PR DESCRIPTION
## Summary
- add reusable `Spinner` and `ErrorBanner` components
- show loading and error state across dashboard and tables, disabling buttons during requests

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af75cdbe2c8323b65c7c4fb1aa3d43