### PR TITLE
feat: validate settings with schema

### DIFF
--- a/app/service.py
+++ b/app/service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from fastapi import FastAPI, HTTPException
-from .settings_service import get_settings, update_settings
+from .settings_service import get_settings, update_settings, FIELD_META, validate_settings
 from .recommender import build_recommendations
 from .scheduler import run_tick
 from .db import connect
@@ -48,10 +48,13 @@ def read_settings():
 
 @app.put("/settings")
 def write_settings(settings: dict):
-    allowed = set(get_settings().keys())
     for key in settings.keys():
-        if key not in allowed:
+        if key not in FIELD_META:
             raise HTTPException(status_code=400, detail=f"Unknown setting {key}")
+    try:
+        validate_settings(settings)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
     update_settings(settings)
     return get_settings()
 

--- a/app/settings_service.py
+++ b/app/settings_service.py
@@ -20,6 +20,47 @@ DEFAULTS: Dict[str, Any] = {
     "SPREAD_BUFFER": config.SPREAD_BUFFER,
 }
 
+# Metadata used for validation and UI hints
+FIELD_META: Dict[str, Dict[str, Any]] = {
+    "STATION_ID": {"type": int, "min": 1},
+    "REGION_ID": {"type": int, "min": 1},
+    "DATASOURCE": {"type": str},
+    "VENUE": {"type": str},
+    "SALES_TAX": {"type": float, "min": 0.0, "max": 1.0},
+    "BROKER_BUY": {"type": float, "min": 0.0, "max": 1.0},
+    "BROKER_SELL": {"type": float, "min": 0.0, "max": 1.0},
+    "RELIST_HAIRCUT": {"type": float, "min": 0.0, "max": 1.0},
+    "MOM_THRESHOLD": {"type": float, "min": 0.0, "max": 1.0},
+    "MIN_DAYS_TRADED": {"type": int, "min": 0},
+    "MIN_DAILY_VOL": {"type": int, "min": 0},
+    "SPREAD_BUFFER": {"type": float, "min": 0.0, "max": 1.0},
+}
+
+
+def validate_settings(updates: Dict[str, Any]) -> None:
+    """Validate incoming settings against type and range constraints."""
+    for key, value in updates.items():
+        meta = FIELD_META.get(key)
+        if not meta:
+            raise ValueError(f"Unknown setting {key}")
+        expected = meta.get("type")
+        if expected is int:
+            try:
+                value = int(value)
+            except (TypeError, ValueError):
+                raise ValueError(f"{key} must be an integer")
+        elif expected is float:
+            try:
+                value = float(value)
+            except (TypeError, ValueError):
+                raise ValueError(f"{key} must be a number")
+        elif expected is str:
+            value = str(value)
+        if "min" in meta and value < meta["min"]:
+            raise ValueError(f"{key} must be >= {meta['min']}")
+        if "max" in meta and value > meta["max"]:
+            raise ValueError(f"{key} must be <= {meta['max']}")
+
 
 def _coerce(key: str, value: str) -> Any:
     """Coerce string values back to the type of the default."""

--- a/tests/test_service_settings.py
+++ b/tests/test_service_settings.py
@@ -1,0 +1,41 @@
+from fastapi.testclient import TestClient
+import sys
+from pathlib import Path
+
+# Ensure 'app' package is importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app import service, db  # noqa
+
+
+def test_update_and_read_settings(tmp_path, monkeypatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "test.sqlite3")
+    db.init_db()
+    client = TestClient(service.app)
+
+    resp = client.get("/settings")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "STATION_ID" in data
+
+    resp = client.put("/settings", json={"STATION_ID": 1234})
+    assert resp.status_code == 200
+    assert resp.json()["STATION_ID"] == 1234
+
+
+def test_reject_unknown_setting(tmp_path, monkeypatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "test.sqlite3")
+    db.init_db()
+    client = TestClient(service.app)
+
+    resp = client.put("/settings", json={"NOT_A_SETTING": 1})
+    assert resp.status_code == 400
+
+
+def test_reject_out_of_range(tmp_path, monkeypatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "test.sqlite3")
+    db.init_db()
+    client = TestClient(service.app)
+
+    resp = client.put("/settings", json={"SALES_TAX": -0.5})
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- validate incoming settings against a schema with type and range checks
- render settings with typed inputs, field help and client-side validation
- add tests for settings update and validation errors

## Testing
- `pytest -q`
- `(cd ui && npm run lint)`

------
https://chatgpt.com/codex/tasks/task_e_68af7836fe2c8323bb67386c3598511d