### PR TITLE
Add watchlist support and UI integration

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -162,6 +162,12 @@ CREATE TABLE IF NOT EXISTS recommendations (
   PRIMARY KEY (type_id, ts_utc)
 );
 
+CREATE TABLE IF NOT EXISTS watchlist (
+  type_id INTEGER PRIMARY KEY,
+  added_ts TEXT NOT NULL,
+  note TEXT
+);
+
 CREATE TABLE IF NOT EXISTS jobs_history (
   name TEXT NOT NULL,
   ts_utc TEXT NOT NULL,

--- a/tests/test_service_watchlist.py
+++ b/tests/test_service_watchlist.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+
+# Ensure 'app' package is importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+from app import service, db
+
+
+def test_watchlist_crud(tmp_path, monkeypatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "test.sqlite3")
+    db.init_db()
+    client = TestClient(service.app)
+
+    resp = client.get("/watchlist")
+    assert resp.status_code == 200
+    assert resp.json()["items"] == []
+
+    resp = client.post("/watchlist/42")
+    assert resp.status_code == 200
+
+    resp = client.get("/watchlist")
+    data = resp.json()
+    assert len(data["items"]) == 1
+    assert data["items"][0]["type_id"] == 42
+
+    resp = client.delete("/watchlist/42")
+    assert resp.status_code == 200
+
+    resp = client.get("/watchlist")
+    assert resp.json()["items"] == []

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -90,6 +90,24 @@ export async function updateSchedulers(settings: Record<string, { enabled: boole
   return res.json();
 }
 
+export async function getWatchlist() {
+  const res = await fetch(`${API_BASE}/watchlist`);
+  if (!res.ok) throw new Error('Failed to fetch watchlist');
+  return res.json();
+}
+
+export async function addWatchlist(typeId: number) {
+  const res = await fetch(`${API_BASE}/watchlist/${typeId}`, { method: 'POST' });
+  if (!res.ok) throw new Error('Failed to add watchlist item');
+  return res.json();
+}
+
+export async function removeWatchlist(typeId: number) {
+  const res = await fetch(`${API_BASE}/watchlist/${typeId}`, { method: 'DELETE' });
+  if (!res.ok) throw new Error('Failed to remove watchlist item');
+  return res.json();
+}
+
 export interface AuthStatus {
   has_token: boolean;
   expires_at: number;


### PR DESCRIPTION
## Summary
- store watchlisted items in new `watchlist` table
- expose watchlist CRUD endpoints
- allow starring recommendations and surface watchlist on dashboard

## Testing
- `pytest`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68af82e2207c8323b3b3363a9400f47e