### PR TITLE
Add CORS middleware and health endpoint

### DIFF
--- a/app/service.py
+++ b/app/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from datetime import datetime
 from .settings_service import get_settings, update_settings, FIELD_META, validate_settings
 from .recommender import build_recommendations
@@ -12,6 +13,18 @@ from .scheduler_config import get_scheduler_settings, update_scheduler_settings
 import json
 
 app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/healthz")
+def healthz():
+    """Simple liveness probe."""
+    return {"status": "ok"}
 
 
 @app.get("/status")

--- a/tests/test_service_healthz.py
+++ b/tests/test_service_healthz.py
@@ -1,0 +1,15 @@
+from fastapi.testclient import TestClient
+import sys
+from pathlib import Path
+
+# Ensure 'app' package importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app import service
+
+
+def test_healthz_ok():
+    client = TestClient(service.app)
+    resp = client.get("/healthz")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- Enable CORS on FastAPI service for cross-origin UI calls
- Add simple `/healthz` liveness endpoint
- Test health endpoint

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af846ecbc8832393f3c3f43a3779cd