### PR TITLE
Ensure integer and float validation for settings

### DIFF
--- a/app/settings_service.py
+++ b/app/settings_service.py
@@ -45,6 +45,8 @@ def validate_settings(updates: Dict[str, Any]) -> None:
             raise ValueError(f"Unknown setting {key}")
         expected = meta.get("type")
         if expected is int:
+            if isinstance(value, float) and not value.is_integer():
+                raise ValueError(f"{key} must be an integer")
             try:
                 value = int(value)
             except (TypeError, ValueError):
@@ -60,6 +62,8 @@ def validate_settings(updates: Dict[str, Any]) -> None:
             raise ValueError(f"{key} must be >= {meta['min']}")
         if "max" in meta and value > meta["max"]:
             raise ValueError(f"{key} must be <= {meta['max']}")
+        # Persist coerced value back into the dict for downstream use
+        updates[key] = value
 
 
 def _coerce(key: str, value: str) -> Any:

--- a/tests/test_service_settings.py
+++ b/tests/test_service_settings.py
@@ -39,3 +39,13 @@ def test_reject_out_of_range(tmp_path, monkeypatch):
 
     resp = client.put("/settings", json={"SALES_TAX": -0.5})
     assert resp.status_code == 400
+
+
+def test_reject_non_integer_id(tmp_path, monkeypatch):
+    """Ensure integer-only fields reject float values."""
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "test.sqlite3")
+    db.init_db()
+    client = TestClient(service.app)
+
+    resp = client.put("/settings", json={"STATION_ID": 123.45})
+    assert resp.status_code == 400

--- a/ui/src/pages/Settings.tsx
+++ b/ui/src/pages/Settings.tsx
@@ -9,21 +9,44 @@ interface FieldMeta {
   min?: number;
   max?: number;
   help?: string;
+  step?: number;
+  integer?: boolean;
 }
 
 const FIELDS: Record<string, FieldMeta> = {
-  STATION_ID: { label: 'Station ID', type: 'number', min: 1, help: 'Default station for valuations' },
-  REGION_ID: { label: 'Region ID', type: 'number', min: 1, help: 'Default region for valuations' },
+  STATION_ID: {
+    label: 'Station ID',
+    type: 'number',
+    min: 1,
+    integer: true,
+    step: 1,
+    help: 'Default station for valuations',
+  },
+  REGION_ID: {
+    label: 'Region ID',
+    type: 'number',
+    min: 1,
+    integer: true,
+    step: 1,
+    help: 'Default region for valuations',
+  },
   DATASOURCE: { label: 'Datasource', type: 'text', help: 'EVE data source' },
   VENUE: { label: 'Venue', type: 'text', help: 'Trading venue' },
-  SALES_TAX: { label: 'Sales Tax', type: 'number', min: 0, max: 1, help: '0.05 for 5% sales tax' },
-  BROKER_BUY: { label: 'Broker Fee (Buy)', type: 'number', min: 0, max: 1 },
-  BROKER_SELL: { label: 'Broker Fee (Sell)', type: 'number', min: 0, max: 1 },
-  RELIST_HAIRCUT: { label: 'Relist Haircut', type: 'number', min: 0, max: 1 },
-  MOM_THRESHOLD: { label: 'MoM Threshold', type: 'number', min: 0, max: 1 },
-  MIN_DAYS_TRADED: { label: 'Min Days Traded', type: 'number', min: 0 },
-  MIN_DAILY_VOL: { label: 'Min Daily Volume', type: 'number', min: 0 },
-  SPREAD_BUFFER: { label: 'Spread Buffer', type: 'number', min: 0, max: 1 },
+  SALES_TAX: {
+    label: 'Sales Tax',
+    type: 'number',
+    min: 0,
+    max: 1,
+    step: 0.01,
+    help: '0.05 for 5% sales tax',
+  },
+  BROKER_BUY: { label: 'Broker Fee (Buy)', type: 'number', min: 0, max: 1, step: 0.01 },
+  BROKER_SELL: { label: 'Broker Fee (Sell)', type: 'number', min: 0, max: 1, step: 0.01 },
+  RELIST_HAIRCUT: { label: 'Relist Haircut', type: 'number', min: 0, max: 1, step: 0.01 },
+  MOM_THRESHOLD: { label: 'MoM Threshold', type: 'number', min: 0, max: 1, step: 0.01 },
+  MIN_DAYS_TRADED: { label: 'Min Days Traded', type: 'number', min: 0, integer: true, step: 1 },
+  MIN_DAILY_VOL: { label: 'Min Daily Volume', type: 'number', min: 0, integer: true, step: 1 },
+  SPREAD_BUFFER: { label: 'Spread Buffer', type: 'number', min: 0, max: 1, step: 0.01 },
 };
 
 export default function Settings() {
@@ -62,7 +85,11 @@ export default function Settings() {
     const meta = FIELDS[key];
     let v: unknown = value;
     if (meta.type === 'number') {
-      v = value === '' ? '' : Number(value);
+      if (value === '') {
+        v = '';
+      } else {
+        v = meta.integer ? parseInt(value, 10) : Number(value);
+      }
     }
     setSettings(s => ({ ...s, [key]: v }));
   }
@@ -73,9 +100,13 @@ export default function Settings() {
       const raw = settings[key];
       let val = raw;
       if (meta.type === 'number') {
-        val = Number(raw);
+        val = meta.integer ? parseInt(String(raw), 10) : Number(raw);
         if (isNaN(val as number)) {
           setError(`${meta.label} must be a number`);
+          return;
+        }
+        if (meta.integer && !Number.isInteger(val)) {
+          setError(`${meta.label} must be an integer`);
           return;
         }
       }
@@ -141,7 +172,7 @@ export default function Settings() {
                 type={meta.type === 'number' ? 'number' : 'text'}
                 min={meta.min}
                 max={meta.max}
-                step="0.01"
+                step={meta.step ?? 'any'}
                 value={settings[k] as number | string}
                 onChange={e => handleChange(k, e.target.value)}
               />


### PR DESCRIPTION
## Summary
- enforce integer-only settings in backend validation
- add step/integer metadata for settings inputs in UI
- test rejection of non-integer station ID

## Testing
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af8899a0948323bd31de33630ef605