### PR TITLE
Preload type names and cache globally

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ fastapi
 httpx
 pandas
 requests
+python-dotenv
 

--- a/ui/src/TypeNamesContext.tsx
+++ b/ui/src/TypeNamesContext.tsx
@@ -1,0 +1,33 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import { getTypeNames } from './api';
+
+/* eslint-disable react-refresh/only-export-components */
+
+const TypeNameContext = createContext<Record<number, string>>({});
+
+export function TypeNameProvider({ children }: { children: ReactNode }) {
+  const [names, setNames] = useState<Record<number, string>>({});
+
+  useEffect(() => {
+    getTypeNames([])
+      .then(setNames)
+      .catch(() => {
+        // ignore errors; fall back to type IDs
+      });
+  }, []);
+
+  return (
+    <TypeNameContext.Provider value={names}>
+      {children}
+    </TypeNameContext.Provider>
+  );
+}
+
+export function useTypeNames(): Record<number, string> {
+  return useContext(TypeNameContext);
+}
+
+export function useTypeName(id: number): string {
+  const names = useTypeNames();
+  return names[id] || String(id);
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -3,11 +3,14 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 import App from './App';
+import { TypeNameProvider } from './TypeNamesContext';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <TypeNameProvider>
+        <App />
+      </TypeNameProvider>
     </BrowserRouter>
   </StrictMode>
 );

--- a/ui/src/pages/Orders.tsx
+++ b/ui/src/pages/Orders.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
-import { getOpenOrders, getOrderHistory, getTypeNames } from '../api';
+import { getOpenOrders, getOrderHistory } from '../api';
 import Spinner from '../Spinner';
 import ErrorBanner from '../ErrorBanner';
+import { useTypeNames } from '../TypeNamesContext';
 
 interface Order {
   order_id: number;
@@ -21,7 +22,7 @@ export default function Orders() {
   const [history, setHistory] = useState<Order[]>([]);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
-  const [typeNames, setTypeNames] = useState<Record<number, string>>({});
+  const typeNames = useTypeNames();
 
   async function refresh() {
     setLoading(true);
@@ -32,11 +33,6 @@ export default function Orders() {
       const histList = hist.orders || [];
       setOpenOrders(openList);
       setHistory(histList);
-      const ids = Array.from(new Set([...openList, ...histList].map((o: Order) => o.type_id)));
-      if (ids.length) {
-        const names = await getTypeNames(ids);
-        setTypeNames(names);
-      }
       setError('');
     } catch (e: unknown) {
       if (e instanceof Error) {

--- a/ui/src/pages/Recommendations.tsx
+++ b/ui/src/pages/Recommendations.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
-import { getRecommendations, getTypeNames, getWatchlist, addWatchlist, removeWatchlist } from '../api';
+import { getRecommendations, getWatchlist, addWatchlist, removeWatchlist } from '../api';
 import Spinner from '../Spinner';
 import ErrorBanner from '../ErrorBanner';
+import { useTypeNames } from '../TypeNamesContext';
 
 interface Rec {
   type_id: number;
@@ -18,7 +19,7 @@ export default function Recommendations() {
   const [minMom, setMinMom] = useState(0);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
-  const [typeNames, setTypeNames] = useState<Record<number, string>>({});
+  const typeNames = useTypeNames();
   const [selected, setSelected] = useState<Rec | null>(null);
   const [watchlist, setWatchlist] = useState<Set<number>>(new Set());
 
@@ -27,13 +28,6 @@ export default function Recommendations() {
     try {
       const data = await getRecommendations(50, minNet, minMom);
       setRecs(data.results || []);
-      const ids: number[] = Array.from(
-        new Set((data.results || []).map((r: Rec) => r.type_id))
-      );
-      if (ids.length) {
-        const names = await getTypeNames(ids);
-        setTypeNames(names);
-      }
       const wl = await getWatchlist();
       setWatchlist(new Set((wl.items || []).map((i: { type_id: number }) => i.type_id)));
       setError('');


### PR DESCRIPTION
## Summary
- preload type name map at startup and provide React context for lookup
- use shared cache in Recommendations and Orders pages
- declare python-dotenv dependency for tests

## Testing
- `pytest`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af8fe0b3d08323a02b42ccca6cd471