### PR TITLE
Add valuations recompute endpoint and UI trigger

### DIFF
--- a/tests/test_service_recompute_valuations.py
+++ b/tests/test_service_recompute_valuations.py
@@ -1,0 +1,60 @@
+from fastapi.testclient import TestClient
+import sys
+from pathlib import Path
+
+# Ensure 'app' package importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app import service, db, valuation
+
+
+def _seed_data(con):
+    # Asset with type_id 1
+    con.execute(
+        """
+        INSERT INTO assets(item_id, type_id, quantity, is_singleton, location_id, location_type, location_flag, updated)
+        VALUES (1,1,1,0,60003760,'station','hangar','2024-01-01')
+        """
+    )
+    # Order with type_id 2
+    con.execute(
+        """
+        INSERT INTO char_orders(
+          order_id, is_buy, region_id, location_id, type_id, price,
+          volume_total, volume_remain, issued, duration, range,
+          min_volume, escrow, last_seen, state)
+        VALUES (1,1,10000002,60003760,2,10,1,1,'2024-01-01',30,'region',1,0,'2024-01-01','open')
+        """
+    )
+    con.commit()
+
+
+def test_recompute_valuations(tmp_path, monkeypatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "test.sqlite3")
+    db.init_db()
+    con = db.connect()
+    try:
+        _seed_data(con)
+    finally:
+        con.close()
+
+    # Stub market lookup to deterministic values
+    monkeypatch.setattr(
+        valuation,
+        "best_bid_ask_station",
+        lambda tid, station, region: (tid * 10.0, tid * 20.0),
+    )
+
+    client = TestClient(service.app)
+    resp = client.post("/valuations/recompute")
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 2
+
+    con = db.connect()
+    try:
+        rows = con.execute(
+            "SELECT type_id, quicksell_bid, mark_ask FROM type_valuations ORDER BY type_id"
+        ).fetchall()
+    finally:
+        con.close()
+    assert rows == [(1, 10.0, 20.0), (2, 20.0, 40.0)]

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -62,6 +62,12 @@ export async function getPortfolioNav() {
   return res.json();
 }
 
+export async function recomputeValuations() {
+  const res = await fetch(`${API_BASE}/valuations/recompute`, { method: 'POST' });
+  if (!res.ok) throw new Error('Failed to recompute valuations');
+  return res.json();
+}
+
 export async function getTypeNames(ids: number[]): Promise<Record<number, string>> {
   const params = ids.length ? `?ids=${ids.join(',')}` : '';
   const res = await fetch(`${API_BASE}/types/map${params}`);

--- a/ui/src/pages/Settings.tsx
+++ b/ui/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { getSettings, updateSettings, getSchedulers, updateSchedulers } from '../api';
+import { getSettings, updateSettings, getSchedulers, updateSchedulers, recomputeValuations } from '../api';
 import Spinner from '../Spinner';
 import ErrorBanner from '../ErrorBanner';
 
@@ -136,6 +136,23 @@ export default function Settings() {
     }
   }
 
+  async function recompute() {
+    setLoading(true);
+    try {
+      await recomputeValuations();
+      alert('Valuations recomputed');
+      setError('');
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        setError(e.message);
+      } else {
+        setError(String(e));
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
   async function saveSchedulers() {
     setLoading(true);
     try {
@@ -185,6 +202,9 @@ export default function Settings() {
           </div>
         ))}
         <button type="submit" disabled={loading}>Save</button>
+        <button type="button" onClick={recompute} disabled={loading} style={{ marginLeft: '0.5em' }}>
+          Recompute valuations
+        </button>
       </form>
 
       <h3>Schedulers</h3>


### PR DESCRIPTION
## Summary
- add `/valuations/recompute` API to refresh type valuations
- expose recompute function to UI and add button in Settings page
- cover recompute flow with tests

## Testing
- `pytest`
- `cd ui && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af90d4b5488323949963666dbe20b2