### PR TITLE
Add cached type names to API responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Features:
 - Region type seeding and Jita order snapshots
 - Trend calculations and scheduling helpers
 - Portfolio valuation and P/L plots
+- Cached type names in API responses
 
 ## Getting Started
 
@@ -21,7 +22,7 @@ Features:
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-pip install requests pandas matplotlib python-dotenv
+pip install -r requirements.txt
 ```
 
 ### Database Initialization
@@ -72,4 +73,5 @@ The service provides endpoints such as:
 - `POST /jobs/scheduler_tick/run` – process due market snapshots
 - `GET /auth/status` – check whether SSO token is cached
 - `POST /auth/connect` – initiate the EVE SSO flow
+- Most responses include `type_name` alongside `type_id`
 

--- a/app/type_cache.py
+++ b/app/type_cache.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+from typing import Dict, Optional
+
+from .db import connect
+
+_type_name_cache: Dict[int, str] | None = None
+
+
+def refresh_type_name_cache() -> None:
+    """Reload the type ID to name mapping from the database."""
+    global _type_name_cache
+    con = connect()
+    try:
+        _type_name_cache = dict(
+            con.execute("SELECT type_id, name FROM types").fetchall()
+        )
+    finally:
+        con.close()
+
+
+def get_type_name(type_id: int) -> Optional[str]:
+    """Return the cached type name for ``type_id`` if available."""
+    if _type_name_cache is None:
+        refresh_type_name_cache()
+    return _type_name_cache.get(type_id) if _type_name_cache else None

--- a/tests/test_service_watchlist.py
+++ b/tests/test_service_watchlist.py
@@ -5,12 +5,22 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from fastapi.testclient import TestClient
-from app import service, db
+from app import service, db, type_cache
 
 
 def test_watchlist_crud(tmp_path, monkeypatch):
     monkeypatch.setattr(db, "DB_PATH", tmp_path / "test.sqlite3")
     db.init_db()
+    con = db.connect()
+    try:
+        con.execute(
+            "INSERT INTO types(type_id, name, group_id) VALUES (42, 'Foo', 10)",
+        )
+        con.commit()
+        type_cache.refresh_type_name_cache()
+    finally:
+        con.close()
+
     client = TestClient(service.app)
 
     resp = client.get("/watchlist")
@@ -23,7 +33,9 @@ def test_watchlist_crud(tmp_path, monkeypatch):
     resp = client.get("/watchlist")
     data = resp.json()
     assert len(data["items"]) == 1
-    assert data["items"][0]["type_id"] == 42
+    item = data["items"][0]
+    assert item["type_id"] == 42
+    assert item["type_name"] == "Foo"
 
     resp = client.delete("/watchlist/42")
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- cache type names at startup and use them in watchlist, recommendations, and orders endpoints
- document requirements install and type name responses

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af938afc988323894e6d23e723d344