### PR TITLE
Initialize database on service startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ pip install -r requirements.txt
 ```
 
 ### Database Initialization
+
+The API service now ensures the SQLite schema exists on startup. If you need to
+initialize the database manually (for example before running standalone
+scripts) you can do so with:
+
 ```bash
 python -c "from app.db import init_db; init_db()"
 ```

--- a/app/service.py
+++ b/app/service.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from .settings_service import get_settings, update_settings, FIELD_META, validate_settings
 from .recommender import build_recommendations
 from .scheduler import run_tick
-from .db import connect
+from .db import connect, init_db
 from .valuation import compute_portfolio_snapshot, refresh_type_valuations
 from .esi import get_error_limit_status
 from .auth import get_token, token_status
@@ -23,8 +23,11 @@ app.add_middleware(
 
 
 @app.on_event("startup")
-def _load_type_cache() -> None:
-    """Preload the type ID to name mapping."""
+def _startup() -> None:
+    """Initialize the SQLite database and preload type names."""
+    # Ensure the database schema exists before serving requests.
+    init_db()
+    # Warm the type ID → name cache for nicer API responses.
     refresh_type_name_cache()
 
 


### PR DESCRIPTION
## Summary
- Ensure FastAPI service creates SQLite schema on startup and warms type name cache
- Document automatic database initialization in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af973e5c708323be314f4a4efe70d0