### PR TITLE
Expose market details and improve formatting

### DIFF
--- a/app/market.py
+++ b/app/market.py
@@ -88,12 +88,14 @@ def evaluate_type(type_id):
     break_even = (1 + BROKER_BUY) / (1 - SALES_TAX - BROKER_SELL) - 1
     if net_pct < (break_even + SPREAD_BUFFER):
         return None
-    daily_isk = df.tail(30)["volume"].mean() * df.tail(7)["average"].mean()
+    daily_vol = df.tail(30)["volume"].mean()
+    daily_isk = daily_vol * df.tail(7)["average"].mean()
     return {
         "type_id": type_id,
         "uplift_mom": uplift,
         "net_spread_pct": net_pct,
         "daily_isk_capacity": daily_isk,
+        "daily_volume": daily_vol,
         "best_bid": bid,
         "best_ask": ask,
     }

--- a/app/service.py
+++ b/app/service.py
@@ -215,6 +215,9 @@ def list_recommendations(limit: int = 50, min_net: float = 0.0, min_mom: float =
                 "net_pct": net,
                 "uplift_mom": mom,
                 "daily_capacity": cap,
+                "best_bid": details.get("best_bid"),
+                "best_ask": details.get("best_ask"),
+                "daily_volume": details.get("daily_volume"),
                 "details": details,
             }
         )

--- a/tests/test_service_recommendations.py
+++ b/tests/test_service_recommendations.py
@@ -14,7 +14,8 @@ def _seed_recommendations(con):
         """
         INSERT INTO recommendations(type_id, ts_utc, net_pct, uplift_mom, daily_capacity, rationale_json)
         VALUES
-        (1, '2024-01-01T00:00:00', 0.1, 0.25, 1000, '{}'),
+        (1, '2024-01-01T00:00:00', 0.1, 0.25, 1000,
+         '{"best_bid": 10.0, "best_ask": 12.0, "daily_volume": 500.0}'),
         (2, '2024-01-02T00:00:00', 0.05, 0.30, 2000, '{}')
         """
     )
@@ -52,6 +53,9 @@ def test_list_recommendations_filters(tmp_path, monkeypatch):
     rec = data["results"][0]
     assert rec["type_id"] == 1
     assert rec["type_name"] == "Foo"
+    assert rec["best_bid"] == 10.0
+    assert rec["best_ask"] == 12.0
+    assert rec["daily_volume"] == 500.0
 
     # Filter by MoM uplift should exclude both when threshold high
     resp = client.get("/recommendations", params={"min_mom": 0.35})

--- a/ui/src/pages/Orders.tsx
+++ b/ui/src/pages/Orders.tsx
@@ -2,12 +2,12 @@ import { useEffect, useState } from 'react';
 import { getOpenOrders, getOrderHistory } from '../api';
 import Spinner from '../Spinner';
 import ErrorBanner from '../ErrorBanner';
-import { useTypeNames } from '../TypeNamesContext';
 
 interface Order {
   order_id: number;
   is_buy: boolean;
   type_id: number;
+  type_name: string;
   price: number;
   volume_total: number;
   volume_remain: number;
@@ -22,7 +22,6 @@ export default function Orders() {
   const [history, setHistory] = useState<Order[]>([]);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
-  const typeNames = useTypeNames();
 
   async function refresh() {
     setLoading(true);
@@ -71,10 +70,10 @@ export default function Orders() {
           {openOrders.map(o => (
             <tr key={o.order_id}>
               <td>{o.order_id}</td>
-              <td>{typeNames[o.type_id] || o.type_id}</td>
-              <td>{o.price.toFixed(2)}</td>
-              <td>{(o.fill_pct * 100).toFixed(1)}</td>
-              <td>{o.escrow.toFixed(2)}</td>
+              <td>{o.type_name || o.type_id}</td>
+              <td>{o.price.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+              <td>{(o.fill_pct * 100).toLocaleString(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 1 })}</td>
+              <td>{o.escrow.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
             </tr>
           ))}
         </tbody>
@@ -95,9 +94,9 @@ export default function Orders() {
           {history.map(o => (
             <tr key={o.order_id}>
               <td>{o.order_id}</td>
-              <td>{typeNames[o.type_id] || o.type_id}</td>
-              <td>{o.price.toFixed(2)}</td>
-              <td>{(o.fill_pct * 100).toFixed(1)}</td>
+              <td>{o.type_name || o.type_id}</td>
+              <td>{o.price.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+              <td>{(o.fill_pct * 100).toLocaleString(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 1 })}</td>
               <td>{o.state}</td>
             </tr>
           ))}

--- a/ui/src/pages/Portfolio.tsx
+++ b/ui/src/pages/Portfolio.tsx
@@ -48,13 +48,13 @@ export default function Portfolio() {
       {snap && (
         <table>
           <tbody>
-            <tr><td>Wallet Balance</td><td>{snap.wallet_balance.toFixed(2)}</td></tr>
-            <tr><td>Buy Escrow</td><td>{snap.buy_escrow.toFixed(2)}</td></tr>
-            <tr><td>Sell Gross</td><td>{snap.sell_gross.toFixed(2)}</td></tr>
-            <tr><td>Inventory (Quicksell)</td><td>{snap.inventory_quicksell.toFixed(2)}</td></tr>
-            <tr><td>Inventory (Mark)</td><td>{snap.inventory_mark.toFixed(2)}</td></tr>
-            <tr><td>NAV (Quicksell)</td><td>{snap.nav_quicksell.toFixed(2)}</td></tr>
-            <tr><td>NAV (Mark)</td><td>{snap.nav_mark.toFixed(2)}</td></tr>
+            <tr><td>Wallet Balance</td><td>{snap.wallet_balance.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td></tr>
+            <tr><td>Buy Escrow</td><td>{snap.buy_escrow.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td></tr>
+            <tr><td>Sell Gross</td><td>{snap.sell_gross.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td></tr>
+            <tr><td>Inventory (Quicksell)</td><td>{snap.inventory_quicksell.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td></tr>
+            <tr><td>Inventory (Mark)</td><td>{snap.inventory_mark.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td></tr>
+            <tr><td>NAV (Quicksell)</td><td>{snap.nav_quicksell.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td></tr>
+            <tr><td>NAV (Mark)</td><td>{snap.nav_mark.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td></tr>
           </tbody>
         </table>
       )}

--- a/ui/src/pages/Recommendations.tsx
+++ b/ui/src/pages/Recommendations.tsx
@@ -2,14 +2,17 @@ import { useEffect, useState } from 'react';
 import { getRecommendations, getWatchlist, addWatchlist, removeWatchlist } from '../api';
 import Spinner from '../Spinner';
 import ErrorBanner from '../ErrorBanner';
-import { useTypeNames } from '../TypeNamesContext';
 
 interface Rec {
   type_id: number;
+  type_name: string;
   ts_utc: string;
   net_pct: number;
   uplift_mom: number;
   daily_capacity: number;
+  best_bid: number | null;
+  best_ask: number | null;
+  daily_volume: number | null;
   details: Record<string, unknown>;
 }
 
@@ -19,7 +22,6 @@ export default function Recommendations() {
   const [minMom, setMinMom] = useState(0);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
-  const typeNames = useTypeNames();
   const [selected, setSelected] = useState<Rec | null>(null);
   const [watchlist, setWatchlist] = useState<Set<number>>(new Set());
 
@@ -87,6 +89,9 @@ export default function Recommendations() {
             <th>Net %</th>
             <th>MoM %</th>
             <th>Daily ISK</th>
+            <th>Bid</th>
+            <th>Ask</th>
+            <th>Volume</th>
             <th>Explain</th>
           </tr>
         </thead>
@@ -101,10 +106,13 @@ export default function Recommendations() {
                   {watchlist.has(r.type_id) ? '★' : '☆'}
                 </button>
               </td>
-              <td>{typeNames[r.type_id] || r.type_id}</td>
-              <td>{(r.net_pct * 100).toFixed(2)}</td>
-              <td>{(r.uplift_mom * 100).toFixed(2)}</td>
-              <td>{Math.round(r.daily_capacity)}</td>
+              <td>{r.type_name || r.type_id}</td>
+              <td>{(r.net_pct * 100).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+              <td>{(r.uplift_mom * 100).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+              <td>{Math.round(r.daily_capacity).toLocaleString()}</td>
+              <td>{(r.best_bid ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+              <td>{(r.best_ask ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+              <td>{(r.daily_volume ?? 0).toLocaleString()}</td>
               <td>
                 <button onClick={() => setSelected(r)}>Explain</button>
               </td>
@@ -128,7 +136,7 @@ export default function Recommendations() {
           }}
         >
           <div style={{ background: '#fff', padding: '1em', maxWidth: '400px' }}>
-            <h3>{typeNames[selected.type_id] || selected.type_id}</h3>
+            <h3>{selected.type_name || selected.type_id}</h3>
             <pre>{JSON.stringify(selected.details, null, 2)}</pre>
             <button onClick={() => setSelected(null)}>Close</button>
           </div>


### PR DESCRIPTION
## Summary
- include best bid/ask and daily volume in recommendation API
- display item names and market details with comma formatting in the UI
- format portfolio and order numbers and use API type names

## Testing
- `pytest`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68af9bb633f48323b645be061b54f4a6