### PR TITLE
Add type name caching with ESI fallback

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -62,6 +62,8 @@ CREATE TABLE IF NOT EXISTS char_orders (
   state TEXT DEFAULT 'open'
 );
 
+CREATE INDEX IF NOT EXISTS idx_char_orders_type ON char_orders(type_id);
+
 CREATE TABLE IF NOT EXISTS assets (
   item_id INTEGER PRIMARY KEY,
   type_id INTEGER,
@@ -73,11 +75,15 @@ CREATE TABLE IF NOT EXISTS assets (
   updated TEXT
 );
 
+CREATE INDEX IF NOT EXISTS idx_assets_type ON assets(type_id);
+
 CREATE TABLE IF NOT EXISTS types (
   type_id INTEGER PRIMARY KEY,
   name TEXT,
   group_id INTEGER
 );
+
+CREATE INDEX IF NOT EXISTS idx_types_name ON types(name);
 
 CREATE TABLE IF NOT EXISTS type_valuations (
   type_id INTEGER PRIMARY KEY,
@@ -125,6 +131,8 @@ CREATE TABLE IF NOT EXISTS market_snapshots (
   PRIMARY KEY (ts_utc, type_id)
 );
 
+CREATE INDEX IF NOT EXISTS idx_market_snapshots_type ON market_snapshots(type_id);
+
 CREATE TABLE IF NOT EXISTS type_trends (
   type_id INTEGER PRIMARY KEY,
   last_history_ts TEXT,
@@ -161,6 +169,8 @@ CREATE TABLE IF NOT EXISTS recommendations (
   rationale_json TEXT,
   PRIMARY KEY (type_id, ts_utc)
 );
+
+CREATE INDEX IF NOT EXISTS idx_recommendations_type ON recommendations(type_id);
 
 CREATE TABLE IF NOT EXISTS watchlist (
   type_id INTEGER PRIMARY KEY,

--- a/app/type_cache.py
+++ b/app/type_cache.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
-from typing import Dict, Optional
+from typing import Dict, Optional, Iterable
+
+import requests
 
 from .db import connect
+from .esi import BASE
+from .config import DATASOURCE
 
 _type_name_cache: Dict[int, str] | None = None
 
@@ -18,8 +22,67 @@ def refresh_type_name_cache() -> None:
         con.close()
 
 
-def get_type_name(type_id: int) -> Optional[str]:
-    """Return the cached type name for ``type_id`` if available."""
+def _fetch_names_from_esi(ids: list[int]) -> Dict[int, str]:
+    """Fetch type names from ESI for the given IDs."""
+    url = f"{BASE}/universe/names/"
+    resp = requests.post(
+        url,
+        json=ids,
+        params={"datasource": DATASOURCE},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    data = resp.json() or []
+    return {row["id"]: row["name"] for row in data}
+
+
+def ensure_type_names(ids: Iterable[int]) -> Dict[int, str]:
+    """Ensure the provided ``ids`` have names cached, fetching from ESI if needed."""
+    unique_ids = list({int(i) for i in ids})
+    if not unique_ids:
+        return {}
+    global _type_name_cache
     if _type_name_cache is None:
         refresh_type_name_cache()
+    known: Dict[int, str] = {}
+    missing: list[int] = []
+    for tid in unique_ids:
+        if _type_name_cache and tid in _type_name_cache:
+            known[tid] = _type_name_cache[tid]
+        else:
+            missing.append(tid)
+    if missing:
+        con = connect()
+        try:
+            placeholders = ",".join("?" for _ in missing)
+            rows = con.execute(
+                f"SELECT type_id, name FROM types WHERE type_id IN ({placeholders})",
+                missing,
+            ).fetchall()
+            for tid, name in rows:
+                known[tid] = name
+                if _type_name_cache is not None:
+                    _type_name_cache[tid] = name
+            still_missing = [tid for tid in missing if tid not in known]
+            if still_missing:
+                fetched = _fetch_names_from_esi(still_missing)
+                if fetched:
+                    con.executemany(
+                        "INSERT OR REPLACE INTO types(type_id, name) VALUES (?, ?)",
+                        fetched.items(),
+                    )
+                    con.commit()
+                    for tid, name in fetched.items():
+                        known[tid] = name
+                        if _type_name_cache is not None:
+                            _type_name_cache[tid] = name
+        finally:
+            con.close()
+    return known
+
+
+def get_type_name(type_id: int) -> Optional[str]:
+    """Return the cached type name for ``type_id``, fetching if unknown."""
+    if _type_name_cache is None or type_id not in _type_name_cache:
+        ensure_type_names([type_id])
     return _type_name_cache.get(type_id) if _type_name_cache else None


### PR DESCRIPTION
## Summary
- index type-related columns for faster joins
- backfill missing type names via ESI and cache results
- test type name fallback behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af9db7d6ec832382bf51e7c5716d47