### PR TITLE
feat: display item names with IDs and copy action

### DIFF
--- a/ui/src/TypeName.tsx
+++ b/ui/src/TypeName.tsx
@@ -1,0 +1,26 @@
+import { useTypeName } from './TypeNamesContext';
+
+interface Props {
+  id: number;
+  name?: string;
+}
+
+export default function TypeName({ id, name }: Props) {
+  const ctxName = useTypeName(id);
+  const display = name || ctxName || String(id);
+  const copy = () => {
+    try {
+      void navigator.clipboard.writeText(String(id));
+    } catch {
+      // ignore clipboard errors
+    }
+  };
+  return (
+    <span>
+      {display} · #{id}{' '}
+      <button onClick={copy} title="Copy type ID" style={{ border: 'none', background: 'none', cursor: 'pointer' }}>
+        📋
+      </button>
+    </span>
+  );
+}

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { getStatus, runJob, type StatusResp, getWatchlist } from '../api';
 import Spinner from '../Spinner';
 import ErrorBanner from '../ErrorBanner';
-import { useTypeNames } from '../TypeNamesContext';
+import TypeName from '../TypeName';
 
 interface JobRec {
   name: string;
@@ -16,7 +16,6 @@ export default function Dashboard() {
   const [error, setError] = useState<string>('');
   const [loading, setLoading] = useState(false);
   const [watchlist, setWatchlist] = useState<number[]>([]);
-  const typeNames = useTypeNames();
 
   async function refresh() {
     setLoading(true);
@@ -79,7 +78,7 @@ export default function Dashboard() {
       <h3>Watchlist</h3>
       <ul>
         {watchlist.map(id => (
-          <li key={id}>{typeNames[id] || id}</li>
+          <li key={id}><TypeName id={id} /></li>
         ))}
       </ul>
     </div>

--- a/ui/src/pages/Orders.tsx
+++ b/ui/src/pages/Orders.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { getOpenOrders, getOrderHistory } from '../api';
 import Spinner from '../Spinner';
 import ErrorBanner from '../ErrorBanner';
+import TypeName from '../TypeName';
 
 interface Order {
   order_id: number;
@@ -70,7 +71,7 @@ export default function Orders() {
           {openOrders.map(o => (
             <tr key={o.order_id}>
               <td>{o.order_id}</td>
-              <td>{o.type_name || o.type_id}</td>
+              <td><TypeName id={o.type_id} name={o.type_name} /></td>
               <td>{o.price.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
               <td>{(o.fill_pct * 100).toLocaleString(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 1 })}</td>
               <td>{o.escrow.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
@@ -94,7 +95,7 @@ export default function Orders() {
           {history.map(o => (
             <tr key={o.order_id}>
               <td>{o.order_id}</td>
-              <td>{o.type_name || o.type_id}</td>
+              <td><TypeName id={o.type_id} name={o.type_name} /></td>
               <td>{o.price.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
               <td>{(o.fill_pct * 100).toLocaleString(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 1 })}</td>
               <td>{o.state}</td>

--- a/ui/src/pages/Recommendations.tsx
+++ b/ui/src/pages/Recommendations.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { getRecommendations, getWatchlist, addWatchlist, removeWatchlist } from '../api';
 import Spinner from '../Spinner';
 import ErrorBanner from '../ErrorBanner';
+import TypeName from '../TypeName';
 
 interface Rec {
   type_id: number;
@@ -106,7 +107,7 @@ export default function Recommendations() {
                   {watchlist.has(r.type_id) ? '★' : '☆'}
                 </button>
               </td>
-              <td>{r.type_name || r.type_id}</td>
+              <td><TypeName id={r.type_id} name={r.type_name} /></td>
               <td>{(r.net_pct * 100).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
               <td>{(r.uplift_mom * 100).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
               <td>{Math.round(r.daily_capacity).toLocaleString()}</td>
@@ -136,7 +137,7 @@ export default function Recommendations() {
           }}
         >
           <div style={{ background: '#fff', padding: '1em', maxWidth: '400px' }}>
-            <h3>{selected.type_name || selected.type_id}</h3>
+            <h3><TypeName id={selected.type_id} name={selected.type_name} /></h3>
             <pre>{JSON.stringify(selected.details, null, 2)}</pre>
             <button onClick={() => setSelected(null)}>Close</button>
           </div>


### PR DESCRIPTION
## Summary
- add reusable `TypeName` component to show item name, id, and copy icon
- use `TypeName` across recommendations, orders, and dashboard screens for consistent labeling

## Testing
- `pytest`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af9efd4e3883238dca92d71cf919f9