### PR TITLE
Add anomaly-aware snipe detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The service provides endpoints such as:
 - `POST /jobs/scheduler_tick/run` – process due market snapshots
 - `GET /auth/status` – check whether SSO token is cached
 - `POST /auth/connect` – initiate the EVE SSO flow
-- `GET /snipes` – detect underpriced sell orders
+- `GET /snipes` – detect underpriced sell orders (supports `limit`, `epsilon`, `min_net`, `z`)
 - Most responses include `type_name` alongside `type_id`
 
 ### Frontend UI

--- a/app/config.py
+++ b/app/config.py
@@ -14,3 +14,7 @@ MIN_DAYS_TRADED = 26
 MIN_DAILY_VOL = 100
 SPREAD_BUFFER = 0.02
 SNIPE_EPSILON = 0.002
+# Z-score threshold for anomaly-based snipes
+SNIPE_Z = 3.0
+# Minimum percentage drop from rolling median for anomaly detection
+SNIPE_DELTA = 0.10

--- a/app/service.py
+++ b/app/service.py
@@ -13,7 +13,7 @@ from .auth import get_token, token_status
 from .scheduler_config import get_scheduler_settings, update_scheduler_settings
 from .type_cache import get_type_name, refresh_type_name_cache, ensure_type_names
 from .snipes import find_snipes
-from .config import SNIPE_EPSILON
+from .config import SNIPE_EPSILON, SNIPE_Z, SPREAD_BUFFER
 import json
 
 
@@ -180,9 +180,23 @@ def remove_watchlist(type_id: int):
 
 
 @app.get("/snipes")
-def list_snipes(limit: int = 20, epsilon: float = SNIPE_EPSILON):
-    """Return potential underpriced sell orders for quick flips."""
-    return {"snipes": find_snipes(limit=limit, epsilon=epsilon)}
+def list_snipes(
+    limit: int = 20,
+    epsilon: float = SNIPE_EPSILON,
+    min_net: float = SPREAD_BUFFER,
+    z: float = SNIPE_Z,
+):
+    """Return potential underpriced sell orders for quick flips.
+
+    ``epsilon`` controls how close the ask must be to the bid for instant flip
+    candidates, ``min_net`` filters by minimum net percentage after fees, and
+    ``z`` is the z-score threshold for anomaly detection.
+    """
+    return {
+        "snipes": find_snipes(
+            limit=limit, epsilon=epsilon, min_net=min_net, z_thresh=z
+        )
+    }
 
 
 @app.get("/recommendations")

--- a/app/snipes.py
+++ b/app/snipes.py
@@ -1,25 +1,39 @@
 from __future__ import annotations
 
+from statistics import median, pstdev
 from typing import List
 
 from .db import connect
-from .config import SPREAD_BUFFER, SNIPE_EPSILON
+from .config import (
+    SPREAD_BUFFER,
+    SNIPE_DELTA,
+    SNIPE_EPSILON,
+    SNIPE_Z,
+)
 from .market import margin_after_fees
 from .type_cache import get_type_name
 
 
-def find_snipes(limit: int = 20, epsilon: float = SNIPE_EPSILON) -> List[dict]:
+def find_snipes(
+    limit: int = 20,
+    epsilon: float = SNIPE_EPSILON,
+    min_net: float = SPREAD_BUFFER,
+    z_thresh: float = SNIPE_Z,
+) -> List[dict]:
     """Return a list of underpriced sell orders worth sniping.
 
-    A snipe is defined as a market snapshot where the best ask is priced very
-    close to or below the best bid. Results are filtered to ensure the net
-    margin after fees meets ``SPREAD_BUFFER``.
+    A snipe is defined as a market snapshot where the best ask is either priced
+    very close to the best bid or is a strong negative anomaly compared to the
+    recent ask history. An anomaly is flagged when the ask is at least
+    ``SNIPE_DELTA`` below the rolling median and the z-score is below
+    ``-z_thresh``. Results are filtered to ensure the net margin after fees
+    meets ``min_net``.
     """
     con = connect()
     try:
         rows = con.execute(
             """
-            SELECT m.type_id, m.best_bid, m.best_ask
+            SELECT m.type_id, m.best_bid, m.best_ask, m.jita_ask_units
             FROM market_snapshots m
             JOIN (
               SELECT type_id, MAX(ts_utc) AS ts
@@ -28,29 +42,49 @@ def find_snipes(limit: int = 20, epsilon: float = SNIPE_EPSILON) -> List[dict]:
             ) latest
             ON latest.type_id = m.type_id AND latest.ts = m.ts_utc
             WHERE m.best_bid IS NOT NULL AND m.best_ask IS NOT NULL
-            """
+            """,
         ).fetchall()
+
+        results: List[dict] = []
+        for type_id, bid, ask, units in rows:
+            hist = [
+                a
+                for (a,) in con.execute(
+                    "SELECT best_ask FROM market_snapshots WHERE type_id=? ORDER BY ts_utc DESC LIMIT 20",
+                    (type_id,),
+                )
+                if a is not None
+            ]
+            med = median(hist) if hist else None
+            sd = pstdev(hist) if len(hist) > 1 else 0.0
+            z = (ask - med) / sd if med is not None and sd > 0 else 0.0
+            anomaly = bool(
+                med is not None
+                and ask <= med * (1 - SNIPE_DELTA)
+                and z < -z_thresh
+            )
+            near_bid = ask <= bid * (1 + epsilon)
+            if not (anomaly or near_bid):
+                continue
+            net = margin_after_fees(buy_px=ask, sell_px=bid)
+            net_pct = net / ask if ask else 0.0
+            if net_pct < min_net:
+                continue
+            results.append(
+                {
+                    "type_id": type_id,
+                    "type_name": get_type_name(type_id),
+                    "best_bid": bid,
+                    "best_ask": ask,
+                    "units": units,
+                    "net": net,
+                    "net_pct": net_pct,
+                    "z_score": z,
+                }
+            )
     finally:
         con.close()
 
-    results: List[dict] = []
-    for type_id, bid, ask in rows:
-        if ask > bid * (1 + epsilon):
-            continue
-        net = margin_after_fees(buy_px=ask, sell_px=bid)
-        net_pct = net / ask if ask else 0.0
-        if net_pct < SPREAD_BUFFER:
-            continue
-        results.append(
-            {
-                "type_id": type_id,
-                "type_name": get_type_name(type_id),
-                "best_bid": bid,
-                "best_ask": ask,
-                "net": net,
-                "net_pct": net_pct,
-            }
-        )
-
     results.sort(key=lambda r: r["net_pct"], reverse=True)
     return results[:limit]
+

--- a/tests/test_service_snipes.py
+++ b/tests/test_service_snipes.py
@@ -47,3 +47,10 @@ def test_snipes_endpoint(tmp_path, monkeypatch):
     assert s["best_bid"] == 100.0
     assert s["best_ask"] == 80.0
     assert s["net_pct"] > 0
+    assert "z_score" in s
+    assert s["units"] == 10
+
+    # min_net filter should drop the candidate when threshold too high
+    resp = client.get("/snipes", params={"min_net": 0.5})
+    assert resp.status_code == 200
+    assert resp.json()["snipes"] == []


### PR DESCRIPTION
## Summary
- enhance /snipes endpoint with rolling-median z-score anomaly checks
- expose epsilon, min_net, and z query parameters for fine-grained filtering
- document new snipes options and cover with tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afa4288ae08323ad8bab842fac465b