### PR TITLE
Add reprice endpoint with tick-aware guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The service provides endpoints such as:
 - `GET /auth/status` – check whether SSO token is cached
 - `POST /auth/connect` – initiate the EVE SSO flow
 - `GET /snipes` – detect underpriced sell orders (supports `limit`, `epsilon`, `min_net`, `z`)
+- `GET /orders/reprice` – tick-aware buy/sell price guidance for a type
 - Most responses include `type_name` alongside `type_id`
 
 ### Frontend UI

--- a/app/ticks.py
+++ b/app/ticks.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+import math
+
+
+def tick_size(price: float) -> float:
+    """Return the market tick size for a given price."""
+    if price < 0:
+        raise ValueError("price must be non-negative")
+    if price < 100:
+        return 0.01
+    if price < 1000:
+        return 0.1
+    if price < 10_000:
+        return 1.0
+    if price < 100_000:
+        return 10.0
+    if price < 1_000_000:
+        return 100.0
+    if price < 10_000_000:
+        return 1_000.0
+    if price < 100_000_000:
+        return 10_000.0
+    if price < 1_000_000_000:
+        return 100_000.0
+    if price < 10_000_000_000:
+        return 1_000_000.0
+    if price < 100_000_000_000:
+        return 10_000_000.0
+    return 100_000_000.0
+
+
+def tick(price: float, direction: str) -> float:
+    """Move ``price`` one tick in ``direction`` ('up' or 'down')."""
+    size = tick_size(price)
+    base = math.floor(price / size) * size
+    if direction == "up":
+        return base + size
+    if direction == "down":
+        return max(0.0, base - size)
+    raise ValueError("direction must be 'up' or 'down'")

--- a/tests/test_service_reprice.py
+++ b/tests/test_service_reprice.py
@@ -1,0 +1,51 @@
+from fastapi.testclient import TestClient
+import sys
+from pathlib import Path
+import pytest
+
+# Ensure 'app' package is importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app import service, db, type_cache
+from app.market import margin_after_fees
+
+
+def _seed(con):
+    con.execute(
+        """
+        INSERT INTO types(type_id, name, group_id) VALUES (1, 'Foo', 10)
+        """,
+    )
+    con.execute(
+        """
+        INSERT INTO market_snapshots(
+            ts_utc, type_id, best_bid, best_ask, bid_count, ask_count, jita_bid_units, jita_ask_units)
+        VALUES ('2024-01-01', 1, 10, 12, 1, 1, 0, 0)
+        """,
+    )
+    con.commit()
+
+
+def test_reprice_endpoint(tmp_path, monkeypatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "test.sqlite3")
+    db.init_db()
+    con = db.connect()
+    try:
+        _seed(con)
+        type_cache.refresh_type_name_cache()
+    finally:
+        con.close()
+
+    client = TestClient(service.app)
+    resp = client.get("/orders/reprice", params={"type_id": 1})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["type_name"] == "Foo"
+    assert data["best_bid"] == 10
+    assert data["best_ask"] == 12
+    assert data["buy_price"] == pytest.approx(10.01)
+    assert data["sell_price"] == pytest.approx(11.99)
+    expected_buy = margin_after_fees(10.01, 12) / 10.01
+    expected_sell = margin_after_fees(10, 11.99) / 10
+    assert data["buy_net_pct"] == pytest.approx(expected_buy)
+    assert data["sell_net_pct"] == pytest.approx(expected_sell)


### PR DESCRIPTION
## Summary
- implement price tick helper and one-tick reprice guidance endpoint
- document new `/orders/reprice` API
- add test coverage for reprice guidance

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afa7d785388323b8c9a39a330cf209