### PR TITLE
Expose scheduler queue in status

### DIFF
--- a/app/jobs.py
+++ b/app/jobs.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 from datetime import datetime
 import json
-from typing import Any, Optional
+from typing import Any, Optional, List, Dict
 from . import db
+
+# Simple in-process queue state for scheduler visibility
+JOB_QUEUE: List[str] = []
+IN_FLIGHT: Optional[Dict[str, str]] = None
 
 
 def record_job(name: str, ok: bool, details: Optional[Any] = None) -> None:

--- a/tests/test_service_status.py
+++ b/tests/test_service_status.py
@@ -8,10 +8,12 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from app import service, db, jobs, esi
 
 
-def test_status_returns_jobs(tmp_path, monkeypatch):
+def test_status_returns_queue_and_counts(tmp_path, monkeypatch):
     monkeypatch.setattr(db, "DB_PATH", tmp_path / "test.sqlite3")
     db.init_db()
     jobs.record_job("sample", True, {"info": 1})
+    jobs.JOB_QUEUE = ["refresh_assets", "recs"]
+    jobs.IN_FLIGHT = {"name": "sync", "started": "2024-01-01T00:00:00"}
     esi.ERROR_LIMIT_REMAIN = 88
     esi.ERROR_LIMIT_RESET = 17
 
@@ -22,5 +24,10 @@ def test_status_returns_jobs(tmp_path, monkeypatch):
     assert len(data["jobs"]) == 1
     assert data["jobs"][0]["name"] == "sample"
     assert data["jobs"][0]["ok"] is True
+    assert data["queue"] == ["refresh_assets", "recs"]
+    assert data["in_flight"]["name"] == "sync"
+    assert data["counts"]["10m"] == 1
+    assert data["counts"]["1h"] == 1
+    assert data["counts"]["24h"] == 1
     assert data["esi"]["error_limit_remain"] == 88
     assert data["esi"]["error_limit_reset"] == 17


### PR DESCRIPTION
## Summary
- track in-process job queue and current job
- expand `/status` to report queue, in-flight job, and recent run counts
- test scheduler status reporting

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afaaf50048832381ab5bd3e6e7a5a8