### PR TITLE
Add priority job queue and ESI rate limiter

### DIFF
--- a/app/jobs.py
+++ b/app/jobs.py
@@ -1,16 +1,133 @@
 from __future__ import annotations
-from datetime import datetime
-import json
-from typing import Any, Optional, List, Dict
-from . import db
 
-# Simple in-process queue state for scheduler visibility
+"""Simple in-process job queue with basic rate limiting.
+
+This module exposes two globals, ``JOB_QUEUE`` and ``IN_FLIGHT``, which are
+used by the ``/status`` API for observability. Jobs can be enqueued with a
+priority (``P0``..``P3``) and are executed in order by ``run_next_job`` or the
+``worker`` loop. A lightweight rate limiter adapts to the ESI error limit
+headers exposed via :mod:`app.esi`.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+import heapq
+import json
+import time
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from . import db, esi
+
+# Public state for status reporting -------------------------------------------------
+
+# Snapshot of queued job names for API consumers.
 JOB_QUEUE: List[str] = []
+
+# Information about the currently running job, if any.
 IN_FLIGHT: Optional[Dict[str, str]] = None
 
 
+# Internal priority queue ----------------------------------------------------------
+
+_PRIORITY = {"P0": 0, "P1": 1, "P2": 2, "P3": 3}
+_queue: List[Tuple[int, int, "Job"]] = []
+_counter = 0
+
+
+@dataclass
+class Job:
+    """A single unit of work to execute."""
+
+    name: str
+    func: Callable[..., Any]
+    args: tuple = ()
+    kwargs: dict = field(default_factory=dict)
+
+
+def _refresh_snapshot() -> None:
+    """Update ``JOB_QUEUE`` snapshot from the internal priority queue."""
+    JOB_QUEUE[:] = [job.name for _, _, job in sorted(_queue)]
+
+
+def enqueue(name: str, func: Callable[..., Any], priority: str = "P2", *args, **kwargs) -> None:
+    """Enqueue a job for later execution."""
+
+    global _counter
+    prio = _PRIORITY.get(priority, 3)
+    heapq.heappush(_queue, (prio, _counter, Job(name, func, args, kwargs)))
+    _counter += 1
+    _refresh_snapshot()
+
+
+def run_next_job() -> bool:
+    """Run the highest-priority job from the queue.
+
+    Returns ``True`` if a job was executed, ``False`` if the queue was empty.
+    """
+
+    if not _queue:
+        return False
+    _, _, job = heapq.heappop(_queue)
+    _refresh_snapshot()
+    global IN_FLIGHT
+    IN_FLIGHT = {"name": job.name, "started": datetime.utcnow().isoformat()}
+    try:
+        job.func(*job.args, **job.kwargs)
+    finally:
+        IN_FLIGHT = None
+    return True
+
+
+def clear_queue() -> None:
+    """Helper to clear internal state (primarily for tests)."""
+
+    global _counter, IN_FLIGHT
+    _queue.clear()
+    JOB_QUEUE.clear()
+    IN_FLIGHT = None
+    _counter = 0
+
+
+# Rate limiter ---------------------------------------------------------------------
+
+
+class RateLimiter:
+    """Token bucket limiter based on cached ESI error limit headers."""
+
+    def allow(self) -> bool:
+        """Return ``True`` if a call should be attempted now."""
+
+        return esi.ERROR_LIMIT_REMAIN > 0
+
+    def backoff(self) -> float:
+        """Return suggested sleep time when the limiter is exhausted."""
+
+        remain = esi.ERROR_LIMIT_REMAIN
+        reset = esi.ERROR_LIMIT_RESET or 1
+        if remain <= 0:
+            # Sleep longer if we have exceeded the error budget.
+            return reset / max(1, abs(remain))
+        if remain < 20:
+            return 1.0
+        return 0.0
+
+
+def worker(limiter: RateLimiter) -> None:
+    """Continuously process queued jobs respecting the rate limiter."""
+
+    while True:
+        if _queue and limiter.allow():
+            run_next_job()
+        else:
+            time.sleep(limiter.backoff())
+
+
+# Job history recording ------------------------------------------------------------
+
+
 def record_job(name: str, ok: bool, details: Optional[Any] = None) -> None:
-    """Record a job execution in the jobs_history table."""
+    """Record a job execution in the ``jobs_history`` table."""
+
     con = db.connect()
     try:
         con.execute(
@@ -28,3 +145,4 @@ def record_job(name: str, ok: bool, details: Optional[Any] = None) -> None:
         con.commit()
     finally:
         con.close()
+

--- a/tests/test_jobs_queue.py
+++ b/tests/test_jobs_queue.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import sys
+
+# Ensure 'app' package importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app import jobs, esi
+
+
+def test_job_queue_and_rate_limiter(monkeypatch):
+    calls = []
+    jobs.clear_queue()
+
+    jobs.enqueue("a", lambda: calls.append("a"), priority="P2")
+    jobs.enqueue("b", lambda: calls.append("b"), priority="P0")
+    jobs.enqueue("c", lambda: calls.append("c"), priority="P1")
+
+    monkeypatch.setattr(esi, "ERROR_LIMIT_REMAIN", 100)
+    monkeypatch.setattr(esi, "ERROR_LIMIT_RESET", 1)
+    limiter = jobs.RateLimiter()
+    assert limiter.allow() is True
+
+    jobs.run_next_job()
+    jobs.run_next_job()
+    jobs.run_next_job()
+    assert calls == ["b", "c", "a"]
+
+    monkeypatch.setattr(esi, "ERROR_LIMIT_REMAIN", 0)
+    monkeypatch.setattr(esi, "ERROR_LIMIT_RESET", 20)
+    assert limiter.allow() is False
+    assert jobs.RateLimiter().backoff() >= 20
+

--- a/tests/test_service_status.py
+++ b/tests/test_service_status.py
@@ -12,7 +12,9 @@ def test_status_returns_queue_and_counts(tmp_path, monkeypatch):
     monkeypatch.setattr(db, "DB_PATH", tmp_path / "test.sqlite3")
     db.init_db()
     jobs.record_job("sample", True, {"info": 1})
-    jobs.JOB_QUEUE = ["refresh_assets", "recs"]
+    jobs.clear_queue()
+    jobs.enqueue("refresh_assets", lambda: None, priority="P1")
+    jobs.enqueue("recs", lambda: None, priority="P2")
     jobs.IN_FLIGHT = {"name": "sync", "started": "2024-01-01T00:00:00"}
     esi.ERROR_LIMIT_REMAIN = 88
     esi.ERROR_LIMIT_RESET = 17


### PR DESCRIPTION
## Summary
- implement in-process job queue with priority levels
- add lightweight rate limiter based on ESI error headers
- cover queue and limiter with unit tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afaf7257688323a548fd6a08276803