### PR TITLE
Expose queue depth by priority in status API

### DIFF
--- a/app/jobs.py
+++ b/app/jobs.py
@@ -42,6 +42,7 @@ class Job:
     func: Callable[..., Any]
     args: tuple = ()
     kwargs: dict = field(default_factory=dict)
+    priority: str = "P2"
 
 
 def _refresh_snapshot() -> None:
@@ -54,9 +55,18 @@ def enqueue(name: str, func: Callable[..., Any], priority: str = "P2", *args, **
 
     global _counter
     prio = _PRIORITY.get(priority, 3)
-    heapq.heappush(_queue, (prio, _counter, Job(name, func, args, kwargs)))
+    heapq.heappush(_queue, (prio, _counter, Job(name, func, args, kwargs, priority)))
     _counter += 1
     _refresh_snapshot()
+
+
+def queue_depth() -> Dict[str, int]:
+    """Return current queued job counts by priority class."""
+
+    counts = {p: 0 for p in _PRIORITY.keys()}
+    for _, _, job in _queue:
+        counts[job.priority] += 1
+    return counts
 
 
 def run_next_job() -> bool:

--- a/app/service.py
+++ b/app/service.py
@@ -78,6 +78,7 @@ def status():
     return {
         "jobs": [{"name": n, "ts_utc": t, "ok": bool(o)} for n, t, o in rows],
         "queue": list(jobs.JOB_QUEUE),
+        "queue_depth": jobs.queue_depth(),
         "in_flight": jobs.IN_FLIGHT,
         "counts": counts,
         "esi": get_error_limit_status(),

--- a/tests/test_service_status.py
+++ b/tests/test_service_status.py
@@ -27,6 +27,7 @@ def test_status_returns_queue_and_counts(tmp_path, monkeypatch):
     assert data["jobs"][0]["name"] == "sample"
     assert data["jobs"][0]["ok"] is True
     assert data["queue"] == ["refresh_assets", "recs"]
+    assert data["queue_depth"] == {"P0": 0, "P1": 1, "P2": 1, "P3": 0}
     assert data["in_flight"]["name"] == "sync"
     assert data["counts"]["10m"] == 1
     assert data["counts"]["1h"] == 1


### PR DESCRIPTION
## Summary
- track job priority when enqueuing and compute queue depth by class
- include per-priority queue depth in `/status` responses
- adjust status test for new field

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afb07c629c8323b7a06f83265aa8a5