### PR TITLE
feat(ui): add snipes page

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -5,6 +5,7 @@ import Settings from './pages/Settings';
 import Recommendations from './pages/Recommendations';
 import Orders from './pages/Orders';
 import Portfolio from './pages/Portfolio';
+import Snipes from './pages/Snipes';
 import Login from './pages/Login';
 import { getAuthStatus } from './api';
 import './App.css';
@@ -23,6 +24,7 @@ export default function App() {
         <Link to="/">Dashboard</Link> |
         <Link to="/recommendations">Recommendations</Link> |
         <Link to="/portfolio">Portfolio</Link> |
+        <Link to="/snipes">Snipes</Link> |
         <Link to="/orders">Orders</Link> |
         <Link to="/settings">Settings</Link>
       </nav>
@@ -30,6 +32,7 @@ export default function App() {
         <Route path="/" element={<Dashboard />} />
         <Route path="/recommendations" element={<Recommendations />} />
         <Route path="/portfolio" element={<Portfolio />} />
+        <Route path="/snipes" element={<Snipes />} />
         <Route path="/orders" element={<Orders />} />
         <Route path="/settings" element={<Settings />} />
         <Route path="/login" element={<Login />} />

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -119,6 +119,34 @@ export async function removeWatchlist(typeId: number) {
   return res.json();
 }
 
+export interface Snipe {
+  type_id: number;
+  type_name: string;
+  best_bid: number;
+  best_ask: number;
+  units: number;
+  net: number;
+  net_pct: number;
+  z_score: number;
+}
+
+export async function getSnipes(
+  limit = 20,
+  minNet = 0.02,
+  epsilon = 0.003,
+  z = 2.5,
+): Promise<{ snipes: Snipe[] }> {
+  const params = new URLSearchParams({
+    limit: String(limit),
+    min_net: String(minNet),
+    epsilon: String(epsilon),
+    z: String(z),
+  });
+  const res = await fetch(`${API_BASE}/snipes?${params.toString()}`);
+  if (!res.ok) throw new Error('Failed to fetch snipes');
+  return res.json();
+}
+
 export interface AuthStatus {
   has_token: boolean;
   expires_at: number;

--- a/ui/src/pages/Snipes.tsx
+++ b/ui/src/pages/Snipes.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react';
+import { getSnipes, Snipe } from '../api';
+import Spinner from '../Spinner';
+import ErrorBanner from '../ErrorBanner';
+import TypeName from '../TypeName';
+
+export default function Snipes() {
+  const [snipes, setSnipes] = useState<Snipe[]>([]);
+  const [limit, setLimit] = useState(20);
+  const [minNet, setMinNet] = useState(0.02);
+  const [epsilon, setEpsilon] = useState(0.003);
+  const [z, setZ] = useState(2.5);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  async function refresh() {
+    setLoading(true);
+    try {
+      const data = await getSnipes(limit, minNet, epsilon, z);
+      setSnipes(data.snipes || []);
+      setError('');
+    } catch (e: unknown) {
+      if (e instanceof Error) setError(e.message);
+      else setError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div>
+      <h2>⚡ Snipes</h2>
+      <ErrorBanner message={error} />
+      {loading && <Spinner />}
+      <div>
+        <label>
+          Limit:{' '}
+          <input type="number" value={limit} onChange={e => setLimit(Number(e.target.value))} />
+        </label>
+        <label style={{ marginLeft: '1em' }}>
+          Min Net %:{' '}
+          <input type="number" value={minNet} step={0.01} onChange={e => setMinNet(Number(e.target.value))} />
+        </label>
+        <label style={{ marginLeft: '1em' }}>
+          Epsilon:{' '}
+          <input type="number" value={epsilon} step={0.001} onChange={e => setEpsilon(Number(e.target.value))} />
+        </label>
+        <label style={{ marginLeft: '1em' }}>
+          Z:{' '}
+          <input type="number" value={z} step={0.1} onChange={e => setZ(Number(e.target.value))} />
+        </label>
+        <button style={{ marginLeft: '1em' }} onClick={refresh} disabled={loading}>
+          Refresh
+        </button>
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>Item</th>
+            <th>Bid</th>
+            <th>Ask</th>
+            <th>Units</th>
+            <th>Net %</th>
+            <th>Net ISK</th>
+            <th>Z-score</th>
+          </tr>
+        </thead>
+        <tbody>
+          {snipes.map(s => (
+            <tr key={s.type_id}>
+              <td><TypeName id={s.type_id} name={s.type_name} /></td>
+              <td>{s.best_bid.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+              <td>{s.best_ask.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+              <td>{s.units.toLocaleString()}</td>
+              <td>{(s.net_pct * 100).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+              <td>{s.net.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+              <td>{s.z_score.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add client API helper for snipes endpoint
- expose Snipes page with filters and table
- wire navigation to new Snipes page

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afb3f76cc0832393b27f2753159222