### PR TITLE
fix(ui): use type-only import for Snipe

### DIFF
--- a/ui/src/pages/Snipes.tsx
+++ b/ui/src/pages/Snipes.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { getSnipes, Snipe } from '../api';
+import { getSnipes, type Snipe } from '../api';
 import Spinner from '../Spinner';
 import ErrorBanner from '../ErrorBanner';
 import TypeName from '../TypeName';


### PR DESCRIPTION
## Summary
- fix Snipes page import to use type-only Snipe interface

## Testing
- `npm run lint`
- `npm run build`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afb5ad0f348323a3f3dd784e7a4faf