### PR TITLE
Add status bus and portfolio summary, refine recommendations API and UI

### DIFF
--- a/app/status.py
+++ b/app/status.py
@@ -1,0 +1,34 @@
+from fastapi import APIRouter, WebSocket
+from typing import Any, Dict, Set
+
+status_router = APIRouter()
+
+# cache filled by scheduler
+STATUS: Dict[str, Any] = {"inflight": [], "last_runs": [], "counts": {}, "esi": {}}
+WS_CLIENTS: Set[WebSocket] = set()
+
+@status_router.get("/status")
+def get_status() -> Dict[str, Any]:
+    return STATUS
+
+@status_router.websocket("/ws")
+async def ws(ws: WebSocket):
+    await ws.accept()
+    WS_CLIENTS.add(ws)
+    try:
+        while True:
+            await ws.receive_text()  # keepalive
+    except Exception:
+        pass
+    finally:
+        WS_CLIENTS.discard(ws)
+
+async def emit(evt: Dict[str, Any]) -> None:
+    dead = []
+    for ws in WS_CLIENTS:
+        try:
+            await ws.send_json(evt)
+        except Exception:
+            dead.append(ws)
+    for ws in dead:
+        WS_CLIENTS.discard(ws)

--- a/tests/test_service_portfolio_summary.py
+++ b/tests/test_service_portfolio_summary.py
@@ -1,0 +1,82 @@
+from fastapi.testclient import TestClient
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app import service, db, config
+
+
+def _seed_portfolio(con):
+    # Wallet balance
+    con.execute(
+        "INSERT INTO wallet_snapshots(ts_utc, balance) VALUES(datetime('now'), 100.0)"
+    )
+    # Buy order with escrow 5
+    con.execute(
+        """
+        INSERT INTO char_orders(
+          order_id, is_buy, region_id, location_id, type_id, price,
+          volume_total, volume_remain, issued, duration, range,
+          min_volume, escrow, last_seen, state)
+        VALUES (1,1,10000002,60003760,1,10,1,1,datetime('now'),30,'region',1,5,datetime('now'),'open')
+        """
+    )
+    # Sell order with price 20
+    con.execute(
+        """
+        INSERT INTO char_orders(
+          order_id, is_buy, region_id, location_id, type_id, price,
+          volume_total, volume_remain, issued, duration, range,
+          min_volume, escrow, last_seen, state)
+        VALUES (2,0,10000002,60003760,1,20,1,1,datetime('now'),30,'region',1,0,datetime('now'),'open')
+        """
+    )
+    # Inventory asset: 2 units of type 1
+    con.execute(
+        """
+        INSERT INTO assets(item_id, type_id, quantity, is_singleton, location_id, location_type, location_flag, updated)
+        VALUES (1,1,2,0,60003760,'station','hangar',datetime('now'))
+        """
+    )
+    # Valuations for type 1
+    con.execute(
+        "INSERT INTO type_valuations(type_id, quicksell_bid, mark_ask, updated) VALUES (1,8,12,datetime('now'))"
+    )
+    # Realized trades
+    con.execute(
+        "INSERT INTO realized_trades(trade_id, ts_utc, type_id, qty, sell_unit_price, cost_total, tax, broker_fee, pnl)"
+        " VALUES('a', datetime('now','-3 days'), 1,1,20,10,1,1,5)"
+    )
+    con.execute(
+        "INSERT INTO realized_trades(trade_id, ts_utc, type_id, qty, sell_unit_price, cost_total, tax, broker_fee, pnl)"
+        " VALUES('b', datetime('now','-20 days'), 1,1,20,10,1,1,7)"
+    )
+    con.commit()
+
+
+def test_portfolio_summary(tmp_path, monkeypatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "test.sqlite3")
+    db.init_db()
+    con = db.connect()
+    try:
+        _seed_portfolio(con)
+    finally:
+        con.close()
+
+    client = TestClient(service.app)
+    resp = client.get("/portfolio/summary", params={"basis": "mark"})
+    assert resp.status_code == 200
+    data = resp.json()
+    sell_net = 20 * (1 - config.SALES_TAX - config.BROKER_SELL)
+    sell_value_qs = 16.0 + sell_net
+    sell_value_mk = 24.0 + sell_net
+    assert data["liquid"] == 100.0
+    assert data["buy_escrow"] == 5.0
+    assert abs(data["sell_value_quicksell"] - sell_value_qs) < 1e-6
+    assert abs(data["sell_value_mark"] - sell_value_mk) < 1e-6
+    assert data["nav_quicksell"] == 100.0 + 5.0 + sell_value_qs
+    assert data["nav_mark"] == 100.0 + 5.0 + sell_value_mk
+    assert data["realized_7d"] == 5.0
+    assert data["realized_30d"] == 12.0
+    assert data["basis"] == "mark"

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ui",
       "version": "0.0.0",
       "dependencies": {
+        "@tanstack/react-table": "^8.21.3",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^6.27.0"
@@ -1356,6 +1357,39 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tanstack/react-table": "^8.21.3",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^6.27.0"

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -1,18 +1,19 @@
 import { useEffect, useState } from 'react';
-import { getStatus, runJob, type StatusResp, getWatchlist } from '../api';
+import { getStatus, runJob, type StatusSnapshot, getWatchlist } from '../api';
 import Spinner from '../Spinner';
 import ErrorBanner from '../ErrorBanner';
 import TypeName from '../TypeName';
 
 interface JobRec {
-  name: string;
-  ts_utc: string;
+  job: string;
+  ts?: string;
   ok: boolean;
+  ms?: number;
 }
 
 export default function Dashboard() {
   const [jobs, setJobs] = useState<JobRec[]>([]);
-  const [esi, setEsi] = useState<StatusResp['esi'] | null>(null);
+  const [esi, setEsi] = useState<StatusSnapshot['esi'] | null>(null);
   const [error, setError] = useState<string>('');
   const [loading, setLoading] = useState(false);
   const [watchlist, setWatchlist] = useState<number[]>([]);
@@ -21,7 +22,7 @@ export default function Dashboard() {
     setLoading(true);
     try {
       const data = await getStatus();
-      setJobs(data.jobs || []);
+      setJobs(data.last_runs || []);
       setEsi(data.esi);
       const wl = await getWatchlist();
       const ids: number[] = (wl.items || []).map((i: { type_id: number }) => i.type_id);
@@ -71,7 +72,7 @@ export default function Dashboard() {
       <h3>Recent Jobs</h3>
       <ul>
         {jobs.map(j => (
-          <li key={j.name + j.ts_utc}>{j.name} @ {j.ts_utc} - {j.ok ? 'OK' : 'Fail'}</li>
+          <li key={j.job + (j.ts || '')}>{j.job} @ {j.ts} - {j.ok ? 'OK' : 'Fail'}</li>
         ))}
       </ul>
 

--- a/ui/src/pages/Recommendations.tsx
+++ b/ui/src/pages/Recommendations.tsx
@@ -3,6 +3,13 @@ import { getRecommendations, getWatchlist, addWatchlist, removeWatchlist } from 
 import Spinner from '../Spinner';
 import ErrorBanner from '../ErrorBanner';
 import TypeName from '../TypeName';
+import {
+  useReactTable,
+  type ColumnDef,
+  getCoreRowModel,
+  getSortedRowModel,
+  type SortingState,
+} from '@tanstack/react-table';
 
 interface Rec {
   type_id: number;
@@ -17,8 +24,27 @@ interface Rec {
   details: Record<string, unknown>;
 }
 
+const columns: ColumnDef<Rec>[] = [
+  {
+    accessorKey: 'type_name',
+    header: 'Item',
+    cell: ({ row }) => `${row.original.type_name} · #${row.original.type_id}`,
+  },
+  { accessorKey: 'uplift_mom', header: 'MoM %', meta: { numeric: true },
+    cell: info => (info.getValue<number>() * 100).toFixed(2) },
+  { accessorKey: 'net_pct', header: 'Net %', meta: { numeric: true },
+    cell: info => (info.getValue<number>() * 100).toFixed(2) },
+  { accessorKey: 'best_bid', header: 'Best Bid', meta: { numeric: true } },
+  { accessorKey: 'best_ask', header: 'Best Ask', meta: { numeric: true } },
+  { accessorKey: 'daily_volume', header: 'Daily Vol', meta: { numeric: true } },
+  { accessorKey: 'ts_utc', header: 'Updated' },
+];
+
 export default function Recommendations() {
-  const [recs, setRecs] = useState<Rec[]>([]);
+  const [rows, setRows] = useState<Rec[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(0);
+  const [sorting, setSorting] = useState<SortingState>([{ id: 'net_pct', desc: true }]);
   const [minNet, setMinNet] = useState(0);
   const [minMom, setMinMom] = useState(0);
   const [search, setSearch] = useState('');
@@ -30,21 +56,43 @@ export default function Recommendations() {
   async function refresh() {
     setLoading(true);
     try {
-      const data = await getRecommendations(50, minNet, minMom, search);
-      setRecs(data.results || []);
+      const sort = sorting[0]?.id ?? 'net_pct';
+      const dir = sorting[0]?.desc ? 'desc' : 'asc';
+      const data = await getRecommendations({
+        limit: 50,
+        offset: page * 50,
+        sort,
+        dir,
+        search,
+        min_net: minNet,
+        min_mom: minMom,
+      });
+      setRows(data.rows || []);
+      setTotal(data.total || 0);
       const wl = await getWatchlist();
       setWatchlist(new Set((wl.items || []).map((i: { type_id: number }) => i.type_id)));
       setError('');
     } catch (e: unknown) {
-      if (e instanceof Error) {
-        setError(e.message);
-      } else {
-        setError(String(e));
-      }
+      setError(e instanceof Error ? e.message : String(e));
     } finally {
       setLoading(false);
     }
   }
+
+  useEffect(() => {
+    refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page, sorting, search]);
+
+  const table = useReactTable({
+    data: rows,
+    columns,
+    state: { sorting },
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    manualSorting: true,
+  });
 
   async function toggleWatchlist(id: number) {
     try {
@@ -60,35 +108,15 @@ export default function Recommendations() {
         setWatchlist(prev => new Set(prev).add(id));
       }
     } catch {
-      // ignore errors
+      // ignore
     }
   }
 
   function exportCsv() {
-    if (!recs.length) return;
-    const headers = [
-      'type_id',
-      'type_name',
-      'net_pct',
-      'uplift_mom',
-      'daily_capacity',
-      'best_bid',
-      'best_ask',
-      'daily_volume',
-      'ts_utc',
-    ];
-    const rows = recs.map(r => [
-      r.type_id,
-      r.type_name,
-      r.net_pct,
-      r.uplift_mom,
-      r.daily_capacity,
-      r.best_bid ?? '',
-      r.best_ask ?? '',
-      r.daily_volume ?? '',
-      r.ts_utc,
-    ]);
-    const csv = [headers.join(','), ...rows.map(row => row.join(','))].join('\n');
+    if (!rows.length) return;
+    const headers = ['type_id','type_name','net_pct','uplift_mom','daily_capacity','best_bid','best_ask','daily_volume','ts_utc'];
+    const csvRows = rows.map(r => [r.type_id,r.type_name,r.net_pct,r.uplift_mom,r.daily_capacity,r.best_bid ?? '',r.best_ask ?? '',r.daily_volume ?? '',r.ts_utc]);
+    const csv = [headers.join(','), ...csvRows.map(r => r.join(','))].join('\n');
     const blob = new Blob([csv], { type: 'text/csv' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
@@ -97,11 +125,6 @@ export default function Recommendations() {
     a.click();
     URL.revokeObjectURL(url);
   }
-
-  useEffect(() => {
-    refresh();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   return (
     <div>
@@ -117,61 +140,48 @@ export default function Recommendations() {
         </label>
         <label style={{ marginLeft: '1em' }}>
           Search:{' '}
-          <input
-            type="text"
-            value={search}
-            onChange={e => setSearch(e.target.value)}
-            placeholder="name or id"
-          />
+          <input type="text" value={search} onChange={e => setSearch(e.target.value)} placeholder="name or id" />
         </label>
         <button style={{ marginLeft: '1em' }} onClick={refresh} disabled={loading}>Refresh</button>
-        <button
-          style={{ marginLeft: '1em' }}
-          onClick={exportCsv}
-          disabled={!recs.length}
-        >
-          Export CSV
-        </button>
+        <button style={{ marginLeft: '1em' }} onClick={exportCsv} disabled={!rows.length}>Export CSV</button>
       </div>
       <table>
         <thead>
-          <tr>
-            <th>★</th>
-            <th>Item</th>
-            <th>Net %</th>
-            <th>MoM %</th>
-            <th>Daily ISK</th>
-            <th>Bid</th>
-            <th>Ask</th>
-            <th>Volume</th>
-            <th>Explain</th>
-          </tr>
+          {table.getHeaderGroups().map(hg => (
+            <tr key={hg.id}>
+              <th>★</th>
+              {hg.headers.map(header => (
+                <th key={header.id} onClick={header.column.getToggleSortingHandler?.()}>
+                  {header.isPlaceholder ? null : header.column.columnDef.header as string}
+                </th>
+              ))}
+              <th>Explain</th>
+            </tr>
+          ))}
         </thead>
         <tbody>
-          {recs.map(r => (
-            <tr key={r.type_id}>
+          {table.getRowModel().rows.map(row => (
+            <tr key={row.original.type_id}>
               <td>
-                <button
-                  onClick={() => toggleWatchlist(r.type_id)}
-                  disabled={loading}
-                >
-                  {watchlist.has(r.type_id) ? '★' : '☆'}
+                <button onClick={() => toggleWatchlist(row.original.type_id)} disabled={loading}>
+                  {watchlist.has(row.original.type_id) ? '★' : '☆'}
                 </button>
               </td>
-              <td><TypeName id={r.type_id} name={r.type_name} /></td>
-              <td>{(r.net_pct * 100).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
-              <td>{(r.uplift_mom * 100).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
-              <td>{Math.round(r.daily_capacity).toLocaleString()}</td>
-              <td>{(r.best_bid ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
-              <td>{(r.best_ask ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
-              <td>{(r.daily_volume ?? 0).toLocaleString()}</td>
-              <td>
-                <button onClick={() => setSelected(r)}>Explain</button>
-              </td>
+              {row.getVisibleCells().map(cell => (
+                <td key={cell.id}>{cell.renderCell()}</td>
+              ))}
+              <td><button onClick={() => setSelected(row.original)}>Explain</button></td>
             </tr>
           ))}
         </tbody>
       </table>
+      <div style={{ marginTop: '1em' }}>
+        <button disabled={page === 0} onClick={() => setPage(p => Math.max(0, p - 1))}>Prev</button>
+        <span style={{ margin: '0 1em' }}>
+          Page {page + 1} / {Math.max(1, Math.ceil(total / 50))}
+        </span>
+        <button disabled={(page + 1) * 50 >= total} onClick={() => setPage(p => p + 1)}>Next</button>
+      </div>
 
       {selected && (
         <div


### PR DESCRIPTION
## Summary
- add WebSocket-capable status bus with REST snapshot
- expose portfolio summary including realized PnL windows
- return recommendation rows with total count and hook up TanStack table on UI

## Testing
- `pytest`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afb70f8f20832395d3f0141d661980