### PR TITLE
Fix UI build errors

### DIFF
--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -65,7 +65,7 @@ export default function Dashboard() {
       <ErrorBanner message={error} />
       {loading && <Spinner />}
       {esi && (
-        <p>ESI Error Limit: {esi.error_limit_remain} (reset {esi.error_limit_reset}s)</p>
+        <p>ESI Error Limit: {esi.remain} (reset {esi.reset}s)</p>
       )}
       <button disabled={loading} onClick={() => run('scheduler_tick')}>Run Scheduler</button>
       <button disabled={loading} onClick={() => run('recommendations')}>Build Recommendations</button>

--- a/ui/src/pages/Recommendations.tsx
+++ b/ui/src/pages/Recommendations.tsx
@@ -9,6 +9,7 @@ import {
   getCoreRowModel,
   getSortedRowModel,
   type SortingState,
+  flexRender,
 } from '@tanstack/react-table';
 
 interface Rec {
@@ -168,7 +169,7 @@ export default function Recommendations() {
                 </button>
               </td>
               {row.getVisibleCells().map(cell => (
-                <td key={cell.id}>{cell.renderCell()}</td>
+                <td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
               ))}
               <td><button onClick={() => setSelected(row.original)}>Explain</button></td>
             </tr>


### PR DESCRIPTION
## Summary
- fix ESI error limit status fields in Dashboard
- use flexRender for table cells in Recommendations

## Testing
- `npm run lint`
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afba98d58083239ca7d819361c96fa