### PR TITLE
feat: expose coverage stats and snapshot freshness

### DIFF
--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -13,6 +13,12 @@ export async function getStatus(): Promise<StatusSnapshot> {
   return res.json();
 }
 
+export async function getCoverage() {
+  const res = await fetch(`${API_BASE}/inventory/coverage`);
+  if (!res.ok) throw new Error('Failed to fetch coverage');
+  return res.json();
+}
+
 export async function getSettings() {
   const res = await fetch(`${API_BASE}/settings`);
   if (!res.ok) throw new Error('Failed to fetch settings');

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { getStatus, runJob, type StatusSnapshot, getWatchlist } from '../api';
+import { getStatus, runJob, type StatusSnapshot, getWatchlist, getCoverage } from '../api';
 import Spinner from '../Spinner';
 import ErrorBanner from '../ErrorBanner';
 import TypeName from '../TypeName';
@@ -17,6 +17,7 @@ export default function Dashboard() {
   const [error, setError] = useState<string>('');
   const [loading, setLoading] = useState(false);
   const [watchlist, setWatchlist] = useState<number[]>([]);
+  const [coverage, setCoverage] = useState<any>(null);
 
   async function refresh() {
     setLoading(true);
@@ -27,6 +28,8 @@ export default function Dashboard() {
       const wl = await getWatchlist();
       const ids: number[] = (wl.items || []).map((i: { type_id: number }) => i.type_id);
       setWatchlist(ids);
+      const cov = await getCoverage();
+      setCoverage(cov);
       setError('');
     } catch (e: unknown) {
       if (e instanceof Error) {
@@ -66,6 +69,12 @@ export default function Dashboard() {
       {loading && <Spinner />}
       {esi && (
         <p>ESI Error Limit: {esi.error_limit_remain} (reset {esi.error_limit_reset}s)</p>
+      )}
+      {coverage && (
+        <p>
+          Types indexed: {coverage.types_indexed} · Books 10m: {coverage.books_last_10m} ·
+          Median age: {Math.round(coverage.median_snapshot_age_ms / 1000)}s
+        </p>
       )}
       <button disabled={loading} onClick={() => run('scheduler_tick')}>Run Scheduler</button>
       <button disabled={loading} onClick={() => run('recommendations')}>Build Recommendations</button>

--- a/ui/src/pages/Recommendations.tsx
+++ b/ui/src/pages/Recommendations.tsx
@@ -21,6 +21,7 @@ interface Rec {
   best_bid: number | null;
   best_ask: number | null;
   daily_volume: number | null;
+  snapshot_age_ms: number | null;
   details: Record<string, unknown>;
 }
 
@@ -37,6 +38,15 @@ const columns: ColumnDef<Rec>[] = [
   { accessorKey: 'best_bid', header: 'Best Bid', meta: { numeric: true } },
   { accessorKey: 'best_ask', header: 'Best Ask', meta: { numeric: true } },
   { accessorKey: 'daily_volume', header: 'Daily Vol', meta: { numeric: true } },
+  {
+    accessorKey: 'snapshot_age_ms',
+    header: 'Fresh',
+    cell: info => {
+      const age = info.getValue<number | null>() ?? 0;
+      const color = age < 120000 ? 'green' : age < 600000 ? 'yellow' : 'red';
+      return <span style={{ color }}>●</span>;
+    }
+  },
   { accessorKey: 'ts_utc', header: 'Updated' },
 ];
 


### PR DESCRIPTION
## Summary
- add `/inventory/coverage` endpoint exposing snapshot stats
- include `snapshot_age_ms` for recommendations and display freshness in UI
- show coverage counts on dashboard

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afba775ef48323900d84c1fa8d9a23