### PR TITLE
feat(ui): show portfolio summary tiles

### DIFF
--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -89,6 +89,12 @@ export async function getPortfolioNav() {
   return res.json();
 }
 
+export async function getPortfolioSummary(basis: 'mark' | 'quicksell' = 'mark') {
+  const res = await fetch(`${API_BASE}/portfolio/summary?basis=${basis}`);
+  if (!res.ok) throw new Error('Failed to fetch portfolio summary');
+  return res.json();
+}
+
 export async function recomputeValuations() {
   const res = await fetch(`${API_BASE}/valuations/recompute`, { method: 'POST' });
   if (!res.ok) throw new Error('Failed to recompute valuations');

--- a/ui/src/pages/Portfolio.tsx
+++ b/ui/src/pages/Portfolio.tsx
@@ -1,35 +1,35 @@
 import { useEffect, useState } from 'react';
-import { getPortfolioNav } from '../api';
+import { getPortfolioSummary } from '../api';
 import Spinner from '../Spinner';
 import ErrorBanner from '../ErrorBanner';
 
-interface Snapshot {
-  wallet_balance: number;
+interface Summary {
+  liquid: number;
   buy_escrow: number;
-  sell_gross: number;
-  inventory_quicksell: number;
-  inventory_mark: number;
+  sell_value_quicksell: number;
+  sell_value_mark: number;
   nav_quicksell: number;
   nav_mark: number;
+  realized_7d: number;
+  realized_30d: number;
+  basis: 'mark' | 'quicksell';
 }
 
 export default function Portfolio() {
-  const [snap, setSnap] = useState<Snapshot | null>(null);
+  const [summary, setSummary] = useState<Summary | null>(null);
+  const [basis, setBasis] = useState<'mark' | 'quicksell'>('mark');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
   async function refresh() {
     setLoading(true);
     try {
-      const data = await getPortfolioNav();
-      setSnap(data);
+      const data = await getPortfolioSummary(basis);
+      setSummary(data);
       setError('');
     } catch (e: unknown) {
-      if (e instanceof Error) {
-        setError(e.message);
-      } else {
-        setError(String(e));
-      }
+      if (e instanceof Error) setError(e.message);
+      else setError(String(e));
     } finally {
       setLoading(false);
     }
@@ -37,26 +37,48 @@ export default function Portfolio() {
 
   useEffect(() => {
     refresh();
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [basis]);
+
+  function format(n: number) {
+    return n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  }
 
   return (
     <div>
       <h2>Portfolio</h2>
       <ErrorBanner message={error} />
       {loading && <Spinner />}
-      <button onClick={refresh} disabled={loading}>Refresh</button>
-      {snap && (
-        <table>
-          <tbody>
-            <tr><td>Wallet Balance</td><td>{snap.wallet_balance.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td></tr>
-            <tr><td>Buy Escrow</td><td>{snap.buy_escrow.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td></tr>
-            <tr><td>Sell Gross</td><td>{snap.sell_gross.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td></tr>
-            <tr><td>Inventory (Quicksell)</td><td>{snap.inventory_quicksell.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td></tr>
-            <tr><td>Inventory (Mark)</td><td>{snap.inventory_mark.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td></tr>
-            <tr><td>NAV (Quicksell)</td><td>{snap.nav_quicksell.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td></tr>
-            <tr><td>NAV (Mark)</td><td>{snap.nav_mark.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td></tr>
-          </tbody>
-        </table>
+      <div style={{ marginBottom: '1em' }}>
+        <button onClick={() => setBasis('mark')} disabled={basis === 'mark'}>
+          Mark
+        </button>
+        <button onClick={() => setBasis('quicksell')} disabled={basis === 'quicksell'} style={{ marginLeft: '0.5em' }}>
+          Quicksell
+        </button>
+        <button onClick={refresh} disabled={loading} style={{ marginLeft: '1em' }}>
+          Refresh
+        </button>
+      </div>
+      {summary && (
+        <div style={{ display: 'flex', gap: '1em', flexWrap: 'wrap' }}>
+          <div style={{ border: '1px solid #ccc', padding: '0.5em', flex: '1 1 150px' }}>
+            <strong>Liquid</strong>
+            <div>{format(summary.liquid)}</div>
+          </div>
+          <div style={{ border: '1px solid #ccc', padding: '0.5em', flex: '1 1 150px' }}>
+            <strong>Buy Escrow</strong>
+            <div>{format(summary.buy_escrow)}</div>
+          </div>
+          <div style={{ border: '1px solid #ccc', padding: '0.5em', flex: '1 1 150px' }}>
+            <strong>Sell Value</strong>
+            <div>{format(basis === 'mark' ? summary.sell_value_mark : summary.sell_value_quicksell)}</div>
+          </div>
+          <div style={{ border: '1px solid #ccc', padding: '0.5em', flex: '1 1 150px' }}>
+            <strong>NAV</strong>
+            <div>{format(basis === 'mark' ? summary.nav_mark : summary.nav_quicksell)}</div>
+          </div>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- fetch portfolio summary snapshot via new API client
- render portfolio overview with basis toggle and four key metrics

## Testing
- `pytest`
- `npm test` *(fails: npm error To see a list of scripts, run: npm run)*

------
https://chatgpt.com/codex/tasks/task_e_68afbc7c6eb083239634f0943412c2c5