### PR TITLE
feat: emit heartbeat events on status WebSocket

### DIFF
--- a/app/service.py
+++ b/app/service.py
@@ -17,7 +17,7 @@ from .snipes import find_snipes
 from .config import SNIPE_EPSILON, SNIPE_Z, SPREAD_BUFFER, STATION_ID
 from .market import margin_after_fees
 from .ticks import tick
-from .status import status_router
+from .status import status_router, start_heartbeat, stop_heartbeat
 import json
 
 
@@ -25,7 +25,11 @@ import json
 async def lifespan(app: FastAPI):
     """Preload the type ID to name mapping."""
     refresh_type_name_cache()
-    yield
+    start_heartbeat()
+    try:
+        yield
+    finally:
+        stop_heartbeat()
 
 
 app = FastAPI(lifespan=lifespan)


### PR DESCRIPTION
## Summary
- add asynchronous heartbeat loop to status bus
- wire heartbeat start and stop into service lifespan

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68afbd188e4c83238eb1cc473550907e