### PR TITLE
fix dashboard types and status snapshot

### DIFF
--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1,10 +1,11 @@
 export const API_BASE = 'http://localhost:8000';
 
 export interface StatusSnapshot {
-  inflight: unknown[];
-  last_runs: { job: string; ok: boolean; ts?: string; ms?: number }[];
-  counts: Record<string, number>;
+  inflight?: unknown[];
+  last_runs?: { job: string; ok: boolean; ts?: string; ms?: number }[];
+  counts?: Record<string, number>;
   esi: { remain?: number; reset?: number };
+  queue?: Record<string, number>;
 }
 
 export async function getStatus(): Promise<StatusSnapshot> {
@@ -13,7 +14,13 @@ export async function getStatus(): Promise<StatusSnapshot> {
   return res.json();
 }
 
-export async function getCoverage() {
+export interface Coverage {
+  types_indexed: number;
+  books_last_10m: number;
+  median_snapshot_age_ms: number;
+}
+
+export async function getCoverage(): Promise<Coverage> {
   const res = await fetch(`${API_BASE}/inventory/coverage`);
   if (!res.ok) throw new Error('Failed to fetch coverage');
   return res.json();

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { API_BASE, getStatus, runJob, type StatusSnapshot, getWatchlist, getCoverage } from '../api';
+import { API_BASE, getStatus, runJob, type StatusSnapshot, getWatchlist, getCoverage, type Coverage } from '../api';
 import Spinner from '../Spinner';
 import ErrorBanner from '../ErrorBanner';
 import TypeName from '../TypeName';
@@ -11,14 +11,21 @@ interface JobRec {
   ms?: number;
 }
 
+interface InflightJob {
+  id: number;
+  job: string;
+  detail?: string;
+  progress: number;
+}
+
 export default function Dashboard() {
   const [jobs, setJobs] = useState<JobRec[]>([]);
   const [esi, setEsi] = useState<StatusSnapshot['esi'] | null>(null);
   const [error, setError] = useState<string>('');
   const [loading, setLoading] = useState(false);
   const [watchlist, setWatchlist] = useState<number[]>([]);
-  const [coverage, setCoverage] = useState<any>(null);
-  const [inflight, setInflight] = useState<any[]>([]);
+  const [coverage, setCoverage] = useState<Coverage | null>(null);
+  const [inflight, setInflight] = useState<InflightJob[]>([]);
   const [queue, setQueue] = useState<Record<string, number>>({});
 
   async function refresh() {
@@ -27,7 +34,7 @@ export default function Dashboard() {
       const data = await getStatus();
       setJobs(data.last_runs || []);
       setEsi(data.esi);
-      setInflight(data.inflight || []);
+      setInflight((data.inflight as InflightJob[]) || []);
       setQueue(data.queue || {});
       const wl = await getWatchlist();
       const ids: number[] = (wl.items || []).map((i: { type_id: number }) => i.type_id);


### PR DESCRIPTION
## Summary
- include queue and coverage types in API
- eliminate `any` usage in Dashboard state

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afbf01f8cc8323a276705ccf4d4e47