### PR TITLE
Surface recent job history in status endpoint

### DIFF
--- a/tests/test_jobs_status_updates.py
+++ b/tests/test_jobs_status_updates.py
@@ -1,0 +1,29 @@
+from fastapi.testclient import TestClient
+import sys
+from pathlib import Path
+
+# Ensure 'app' package importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app import service, db
+from app.jobs import record_job
+from app.status import STATUS
+
+
+def test_record_job_updates_status(tmp_path, monkeypatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "test.sqlite3")
+    db.init_db()
+
+    # reset status snapshot
+    STATUS["last_runs"] = []
+    STATUS["counts"] = {}
+
+    record_job("sample", True, {"ms": 50})
+
+    client = TestClient(service.app)
+    resp = client.get("/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["last_runs"][0]["job"] == "sample"
+    assert data["last_runs"][0]["ok"] is True
+    assert data["counts"]["jobs_10m"] == 1


### PR DESCRIPTION
## Summary
- maintain in-memory snapshot of recent jobs and counts when recording jobs
- expose job history via `/status` endpoint for dashboard visibility
- add regression test for status updates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afc190500083239444b38cc152a55d