### PR TITLE
feat: allow showing all recommendations

### DIFF
--- a/tests/test_service_recommendations.py
+++ b/tests/test_service_recommendations.py
@@ -189,3 +189,23 @@ def test_recommendations_without_type_entries(tmp_path, monkeypatch):
     assert data["total"] == 2
     assert {r["type_id"] for r in data["rows"]} == {1, 2}
 
+
+def test_recommendations_show_all(tmp_path, monkeypatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "test.sqlite3")
+    db.init_db()
+    con = db.connect()
+    try:
+        _seed_types(con)
+        _seed_trends(con)
+        _seed_snapshots(con)
+        # note: do not seed recommendations to simulate empty table
+    finally:
+        con.close()
+
+    client = TestClient(service.app)
+    resp = client.get("/recommendations", params={"all": True})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 2
+    assert {r["type_id"] for r in data["rows"]} == {1, 2}
+

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -57,6 +57,7 @@ export interface RecParams {
   min_net?: number;
   min_mom?: number;
   min_vol?: number;
+  all?: boolean;
 }
 
 export async function getRecommendations(params: RecParams = {}) {
@@ -69,6 +70,7 @@ export async function getRecommendations(params: RecParams = {}) {
   if (params.min_net !== undefined) qs.set('min_net', String(params.min_net));
   if (params.min_mom !== undefined) qs.set('min_mom', String(params.min_mom));
   if (params.min_vol !== undefined) qs.set('min_vol', String(params.min_vol));
+  if (params.all) qs.set('all', 'true');
   const res = await fetch(`${API_BASE}/recommendations?${qs.toString()}`);
   if (!res.ok) throw new Error('Failed to fetch recommendations');
   return res.json();

--- a/ui/src/pages/Recommendations.tsx
+++ b/ui/src/pages/Recommendations.tsx
@@ -63,6 +63,7 @@ export default function Recommendations() {
   const [loading, setLoading] = useState(false);
   const [selected, setSelected] = useState<Rec | null>(null);
   const [watchlist, setWatchlist] = useState<Set<number>>(new Set());
+  const [showAll, setShowAll] = useState(false);
 
   async function refresh() {
     setLoading(true);
@@ -77,6 +78,7 @@ export default function Recommendations() {
         search,
         min_net: minNet,
         min_mom: minMom,
+        all: showAll,
       });
       setRows(data.rows || []);
       setTotal(data.total || 0);
@@ -93,7 +95,7 @@ export default function Recommendations() {
   useEffect(() => {
     refresh();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [page, sorting, search]);
+  }, [page, sorting, search, showAll]);
 
   const table = useReactTable({
     data: rows,
@@ -155,6 +157,9 @@ export default function Recommendations() {
         </label>
         <button style={{ marginLeft: '1em' }} onClick={refresh} disabled={loading}>Refresh</button>
         <button style={{ marginLeft: '1em' }} onClick={exportCsv} disabled={!rows.length}>Export CSV</button>
+        <label style={{ marginLeft: '1em' }}>
+          <input type="checkbox" checked={showAll} onChange={e => setShowAll(e.target.checked)} /> Show All
+        </label>
       </div>
       <table>
         <thead>


### PR DESCRIPTION
## Summary
- add optional `all` flag to `/recommendations` to include all trending types
- expose `all` flag in frontend and UI with a Show All toggle
- test that `all=true` returns types even without recommendations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afc57cce108323b1afdc7dcee919ae