### PR TITLE
Boost scheduler throughput and add Runway telemetry panel

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -6,6 +6,7 @@ import Recommendations from './pages/Recommendations';
 import Orders from './pages/Orders';
 import Portfolio from './pages/Portfolio';
 import Snipes from './pages/Snipes';
+import Runway from './pages/Runway';
 import Login from './pages/Login';
 import { getAuthStatus } from './api';
 import './App.css';
@@ -26,6 +27,7 @@ export default function App() {
         <Link to="/portfolio">Portfolio</Link> |
         <Link to="/snipes">Snipes</Link> |
         <Link to="/orders">Orders</Link> |
+        <Link to="/runway">Runway</Link> |
         <Link to="/settings">Settings</Link>
       </nav>
       <Routes>
@@ -34,6 +36,7 @@ export default function App() {
         <Route path="/portfolio" element={<Portfolio />} />
         <Route path="/snipes" element={<Snipes />} />
         <Route path="/orders" element={<Orders />} />
+        <Route path="/runway" element={<Runway />} />
         <Route path="/settings" element={<Settings />} />
         <Route path="/login" element={<Login />} />
       </Routes>

--- a/ui/src/pages/Runway.tsx
+++ b/ui/src/pages/Runway.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+import { API_BASE, getStatus, type StatusSnapshot } from '../api';
+import ErrorBanner from '../ErrorBanner';
+import Spinner from '../Spinner';
+
+interface EventLog {
+  type: string;
+  [key: string]: unknown;
+}
+
+export default function Runway() {
+  const [status, setStatus] = useState<StatusSnapshot | null>(null);
+  const [events, setEvents] = useState<EventLog[]>([]);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    getStatus().then(setStatus).catch(e => setError(String(e)));
+    const wsUrl = API_BASE.replace(/^http/, 'ws') + '/ws';
+    const ws = new WebSocket(wsUrl);
+    ws.onmessage = ev => {
+      try {
+        const data = JSON.parse(ev.data);
+        setEvents(prev => [...prev.slice(-99), data]);
+        if (data.type === 'counts' && data.counts) {
+          setStatus(s => ({ ...(s || {}), counts: data.counts }));
+        }
+        if (data.type === 'esi') {
+          setStatus(s => ({ ...(s || {}), esi: { remain: data.remain, reset: data.reset } }));
+        }
+        if (data.type === 'queue') {
+          setStatus(s => ({ ...(s || {}), queue: data.depth }));
+        }
+      } catch {
+        // ignore
+      }
+    };
+    ws.onerror = () => setError('WebSocket error');
+    return () => ws.close();
+  }, []);
+
+  if (!status && !error) return <Spinner />;
+
+  const counts = status?.counts || {};
+  return (
+    <div>
+      <h2>Runway</h2>
+      <ErrorBanner message={error} />
+      <div>Types last 10m: {counts['types_10m'] ?? 0}</div>
+      <div>Types last 1h: {counts['types_1h'] ?? 0}</div>
+      <div>ESI Remaining: {status?.esi?.remain ?? ''}</div>
+      <div>Queue: {JSON.stringify(status?.queue || {})}</div>
+      <h3>Events</h3>
+      <ul style={{ maxHeight: '200px', overflowY: 'auto' }}>
+        {events.map((e, i) => (
+          <li key={i}>{e.type}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Bump scheduler tick to handle up to 800 types with up to 6 adaptive workers reacting to ESI error headers; halve A/B tier intervals and seed queue with 1500 types
- Emit recent refresh counts and add a Runway page displaying live scheduler, ESI, and queue telemetry

## Testing
- `pytest`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afd9420bb8832385a209e205d66025