### PR TITLE
fix: allow optional ESI status

### DIFF
--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -4,7 +4,7 @@ export interface StatusSnapshot {
   inflight?: unknown[];
   last_runs?: { job: string; ok: boolean; ts?: string; ms?: number }[];
   counts?: Record<string, number>;
-  esi: { remain?: number; reset?: number };
+  esi?: { remain?: number; reset?: number };
   queue?: Record<string, number>;
 }
 


### PR DESCRIPTION
## Summary
- allow the ESI property in `StatusSnapshot` to be optional

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afdb9837ec8323bd29fc39df0c9ced