### PR TITLE
feat: websocket event stream and runway panel

### DIFF
--- a/app/emit.py
+++ b/app/emit.py
@@ -1,0 +1,101 @@
+import asyncio
+import time
+from uuid import uuid4
+from typing import Optional
+from .ws_bus import broadcast
+from . import status
+
+
+def run_id() -> str:
+    return f"run-{uuid4().hex[:8]}"
+
+
+async def _send(evt: dict) -> None:
+    status.update_status(evt)
+    await broadcast(evt)
+
+
+def emit_sync(evt: dict) -> None:
+    """Best-effort helper to emit an event from sync code."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        asyncio.run(_send(evt))
+    else:
+        loop.create_task(_send(evt))
+
+
+# Job event helpers ------------------------------------------------------------------
+
+def job_started(job: str, meta: Optional[dict] = None) -> str:
+    rid = run_id()
+    emit_sync({"type": "job_started", "job": job, "runId": rid, "meta": meta or {}})
+    return rid
+
+
+def job_progress(runId: str, progress: int, detail: str = "") -> None:
+    emit_sync({"type": "job_progress", "runId": runId, "progress": progress, "detail": detail})
+
+
+_last_log_ts = 0.0
+_log_count = 0
+
+
+def job_log(runId: str, level: str, message: str) -> None:
+    """Emit log messages with simple backpressure to avoid floods."""
+    global _last_log_ts, _log_count
+    now = time.time()
+    if now - _last_log_ts > 1.0:
+        # new window
+        _last_log_ts = now
+        if _log_count > 5:
+            emit_sync({"type": "job_log", "runId": runId, "level": level, "message": f"{_log_count} messages"})
+        _log_count = 0
+    _log_count += 1
+    if _log_count <= 5:
+        emit_sync({"type": "job_log", "runId": runId, "level": level, "message": message})
+
+
+def job_finished(runId: str, ok: bool, items: int = 0, ms: int = 0, error: str | None = None) -> None:
+    evt = {
+        "type": "job_finished",
+        "runId": runId,
+        "ok": ok,
+        "itemsWritten": items,
+        "ms": ms,
+        "error": error,
+    }
+    emit_sync(evt)
+
+
+# Build events -----------------------------------------------------------------------
+
+def build_started(job: str, meta: Optional[dict] = None) -> str:
+    bid = run_id()
+    emit_sync({"type": "build_started", "buildId": bid, "job": job, "meta": meta or {}})
+    return bid
+
+
+def build_progress(buildId: str, progress: int, stage: str = "", detail: str = "") -> None:
+    emit_sync(
+        {
+            "type": "build_progress",
+            "buildId": buildId,
+            "progress": progress,
+            "stage": stage,
+            "detail": detail,
+        }
+    )
+
+
+def build_finished(buildId: str, ok: bool, rows: int = 0, ms: int = 0, error: str | None = None) -> None:
+    emit_sync(
+        {
+            "type": "build_finished",
+            "buildId": buildId,
+            "ok": ok,
+            "rows": rows,
+            "ms": ms,
+            "error": error,
+        }
+    )

--- a/app/service.py
+++ b/app/service.py
@@ -17,7 +17,8 @@ from .snipes import find_snipes
 from .config import SNIPE_EPSILON, SNIPE_Z, SPREAD_BUFFER, STATION_ID, REC_FRESH_MS
 from .market import margin_after_fees
 from .ticks import tick
-from .status import status_router, start_heartbeat, stop_heartbeat
+from .status import status_router
+from .ws_bus import router as ws_router, start_heartbeat, stop_heartbeat
 import json
 
 
@@ -41,6 +42,7 @@ app.add_middleware(
 )
 
 app.include_router(status_router)
+app.include_router(ws_router)
 
 
 

--- a/app/ws_bus.py
+++ b/app/ws_bus.py
@@ -1,0 +1,70 @@
+from fastapi import APIRouter, WebSocket
+import asyncio
+import json
+from datetime import datetime
+
+router = APIRouter()
+_clients: set[WebSocket] = set()
+_history: list[dict] = []
+HISTORY_MAX = 200
+
+
+async def broadcast(evt: dict) -> None:
+    """Send an event to all connected WebSocket clients and store history."""
+    _history.append(evt)
+    if len(_history) > HISTORY_MAX:
+        _history.pop(0)
+    dead = []
+    for ws in list(_clients):
+        try:
+            await ws.send_text(json.dumps(evt))
+        except Exception:
+            dead.append(ws)
+    for ws in dead:
+        _clients.discard(ws)
+
+
+@router.websocket("/ws")
+async def ws(ws: WebSocket):
+    """WebSocket endpoint broadcasting structured events."""
+    await ws.accept()
+    _clients.add(ws)
+    # hydrate late joiners with recent history
+    for evt in _history[-40:]:
+        await ws.send_text(json.dumps(evt))
+    try:
+        while True:
+            # keepalive (we ignore any received data)
+            await ws.receive_text()
+    except Exception:
+        pass
+    finally:
+        _clients.discard(ws)
+
+
+_heartbeat_task: asyncio.Task | None = None
+
+
+async def _heartbeat_loop() -> None:
+    while True:
+        await broadcast({"type": "heartbeat", "now": datetime.utcnow().isoformat() + "Z"})
+        await asyncio.sleep(5)
+
+
+def start_heartbeat() -> None:
+    """Launch background heartbeat broadcaster."""
+    global _heartbeat_task
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    if _heartbeat_task is None or _heartbeat_task.done():
+        _heartbeat_task = loop.create_task(_heartbeat_loop())
+
+
+def stop_heartbeat() -> None:
+    """Stop heartbeat broadcaster if running."""
+    global _heartbeat_task
+    if _heartbeat_task is not None:
+        _heartbeat_task.cancel()
+        _heartbeat_task = None

--- a/ui/src/pages/Runway.tsx
+++ b/ui/src/pages/Runway.tsx
@@ -1,58 +1,104 @@
-import { useEffect, useState } from 'react';
-import { API_BASE, getStatus, type StatusSnapshot } from '../api';
-import ErrorBanner from '../ErrorBanner';
-import Spinner from '../Spinner';
+import React from "react";
+import { useEventStream } from "../useEventStream";
 
-interface EventLog {
-  type: string;
-  [key: string]: unknown;
+function useRunwayVM(events: any[]) {
+  const inflight: Record<string, any> = {};
+  const builds: Record<string, any> = {};
+  let esi = { remain: null, reset: null } as any;
+  let queue = { P0: 0, P1: 0, P2: 0, P3: 0 };
+  const logs: any[] = [];
+
+  for (const e of events) {
+    if (e.type === "job_started") inflight[e.runId] = { ...e, progress: 0 };
+    if (e.type === "job_progress" && inflight[e.runId])
+      (inflight[e.runId].progress = e.progress,
+      (inflight[e.runId].detail = e.detail));
+    if (e.type === "job_log") logs.push(e);
+    if (e.type === "job_finished")
+      inflight[e.runId] = { ...inflight[e.runId], ...e, done: true };
+    if (e.type === "build_started") builds[e.buildId] = { ...e, progress: 0 };
+    if (e.type === "build_progress" && builds[e.buildId])
+      (builds[e.buildId].progress = e.progress,
+      (builds[e.buildId].stage = e.stage),
+      (builds[e.buildId].detail = e.detail));
+    if (e.type === "build_finished")
+      builds[e.buildId] = { ...builds[e.buildId], ...e, done: true };
+    if (e.type === "esi") esi = { remain: e.remain, reset: e.reset };
+    if (e.type === "queue") queue = e.depth;
+  }
+  const inflightList = Object.values(inflight).filter((x: any) => !x.done);
+  const recentJobs = Object.values(inflight)
+    .filter((x: any) => x.done)
+    .slice(-10)
+    .reverse();
+  const recentBuilds = Object.values(builds)
+    .filter((x: any) => x.done)
+    .slice(-5)
+    .reverse();
+  return { inflightList, recentJobs, recentBuilds, esi, queue, logs };
 }
 
 export default function Runway() {
-  const [status, setStatus] = useState<StatusSnapshot | null>(null);
-  const [events, setEvents] = useState<EventLog[]>([]);
-  const [error, setError] = useState('');
+  const { connected, events } = useEventStream();
+  const { inflightList, recentBuilds, esi, queue, logs } = useRunwayVM(events);
+  const dotStyle: React.CSSProperties = {
+    width: 10,
+    height: 10,
+    borderRadius: "50%",
+    backgroundColor: connected ? "green" : "red",
+    display: "inline-block",
+    marginRight: 8,
+  };
+  const trunc = (s: string) => (s && s.length > 80 ? s.slice(0, 80) + "…" : s);
 
-  useEffect(() => {
-    getStatus().then(setStatus).catch(e => setError(String(e)));
-    const wsUrl = API_BASE.replace(/^http/, 'ws') + '/ws';
-    const ws = new WebSocket(wsUrl);
-    ws.onmessage = ev => {
-      try {
-        const data = JSON.parse(ev.data);
-        setEvents(prev => [...prev.slice(-99), data]);
-        if (data.type === 'counts' && data.counts) {
-          setStatus(s => ({ ...(s || {}), counts: data.counts }));
-        }
-        if (data.type === 'esi') {
-          setStatus(s => ({ ...(s || {}), esi: { remain: data.remain, reset: data.reset } }));
-        }
-        if (data.type === 'queue') {
-          setStatus(s => ({ ...(s || {}), queue: data.depth }));
-        }
-      } catch {
-        // ignore
-      }
-    };
-    ws.onerror = () => setError('WebSocket error');
-    return () => ws.close();
-  }, []);
-
-  if (!status && !error) return <Spinner />;
-
-  const counts = status?.counts || {};
   return (
     <div>
       <h2>Runway</h2>
-      <ErrorBanner message={error} />
-      <div>Types last 10m: {counts['types_10m'] ?? 0}</div>
-      <div>Types last 1h: {counts['types_1h'] ?? 0}</div>
-      <div>ESI Remaining: {status?.esi?.remain ?? ''}</div>
-      <div>Queue: {JSON.stringify(status?.queue || {})}</div>
-      <h3>Events</h3>
-      <ul style={{ maxHeight: '200px', overflowY: 'auto' }}>
-        {events.map((e, i) => (
-          <li key={i}>{e.type}</li>
+      <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+        <span style={dotStyle}></span>
+        <span>
+          ESI remain: {esi.remain ?? ""} reset: {esi.reset ?? ""}
+        </span>
+      </div>
+      <h3>Now Running</h3>
+      <ul>
+        {inflightList.length === 0 && <li>None</li>}
+        {inflightList.map((j: any) => (
+          <li key={j.runId} title={j.detail}>
+            <strong>{j.job}</strong> {j.progress}% {trunc(j.detail)}
+          </li>
+        ))}
+      </ul>
+      <h3>Queue</h3>
+      <div>
+        {Object.entries(queue).map(([k, v]) => (
+          <span
+            key={k}
+            style={{
+              marginRight: "8px",
+              padding: "2px 4px",
+              border: "1px solid #ccc",
+              borderRadius: "4px",
+            }}
+          >
+            {k}:{String(v)}
+          </span>
+        ))}
+      </div>
+      <h3>Recent Builds</h3>
+      <ul>
+        {recentBuilds.map((b: any) => (
+          <li key={b.buildId} title={b.detail}>
+            <strong>{b.job}</strong> {b.progress}% {b.stage} {trunc(b.detail)}
+          </li>
+        ))}
+      </ul>
+      <h3>Logs</h3>
+      <ul>
+        {logs.slice(-50).map((l: any, i: number) => (
+          <li key={i} title={l.message}>
+            {l.level}: {trunc(l.message)}
+          </li>
         ))}
       </ul>
     </div>

--- a/ui/src/useEventStream.ts
+++ b/ui/src/useEventStream.ts
@@ -1,0 +1,67 @@
+import { useEffect, useRef, useState } from "react";
+import { API_BASE, getStatus } from "./api";
+
+export function useEventStream() {
+  const [connected, setConnected] = useState(false);
+  const [events, setEvents] = useState<any[]>(() => {
+    try {
+      const cached = sessionStorage.getItem("runway_events");
+      return cached ? JSON.parse(cached) : [];
+    } catch {
+      return [];
+    }
+  });
+  const wsRef = useRef<WebSocket | null>(null);
+
+  useEffect(() => {
+    function stash(evts: any[]) {
+      try {
+        sessionStorage.setItem("runway_events", JSON.stringify(evts.slice(-200)));
+      } catch {}
+    }
+
+    let ws: WebSocket | null = new WebSocket(
+      `${location.protocol === "https:" ? "wss" : "ws"}://${location.host}/ws`
+    );
+    wsRef.current = ws;
+    ws.onopen = () => setConnected(true);
+    ws.onclose = () => setConnected(false);
+    ws.onerror = () => setConnected(false);
+    ws.onmessage = (e) => {
+      const evt = JSON.parse(e.data);
+      setEvents((prev) => {
+        const next = [...prev.slice(-199), evt];
+        stash(next);
+        return next;
+      });
+    };
+    const ping = setInterval(() => ws && ws.readyState === 1 && ws.send("ping"), 10000);
+    return () => {
+      clearInterval(ping);
+      ws && ws.close();
+    };
+  }, []);
+
+  // Fallback polling when disconnected -------------------------------------------------
+  useEffect(() => {
+    let poll: any;
+    async function refresh() {
+      try {
+        const snap = await getStatus();
+        setEvents((prev) => {
+          const evtList = [...prev, ...snap.logs.map((l: any) => ({ ...l, polled: true }))];
+          return evtList.slice(-200);
+        });
+      } catch {
+        /* ignore */
+      }
+    }
+    if (!connected) {
+      refresh();
+      poll = setInterval(refresh, 2000);
+    }
+    return () => poll && clearInterval(poll);
+  }, [connected]);
+
+  return { connected, events };
+}


### PR DESCRIPTION
## Summary
- add FastAPI websocket hub with heartbeat and ring buffer
- instrument jobs and scheduler with structured event helpers
- add React hook and Runway panel to display live job/build status

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afdd16bffc8323812f98725b72304a