### PR TITLE
feat: emit build events for recommendations

### DIFF
--- a/app/recommender.py
+++ b/app/recommender.py
@@ -1,20 +1,33 @@
 import json
+import time
 from .db import connect
 from .market import evaluate_type
 from .config import MIN_DAILY_VOL, STATION_ID
 from .jobs import record_job
+from .emit import build_started, build_progress, build_finished
 
 
-def build_recommendations(limit=50):
-    """Populate the recommendations table with top candidates."""
+def build_recommendations(limit: int = 50, verbose: bool = False):
+    """Populate the recommendations table with top candidates.
+
+    Emits ``build_*`` events so the UI can surface progress for the
+    recommendations build. When ``verbose`` is ``True`` extra progress
+    updates are sent to help manual QA.
+    """
+
+    t0 = time.time()
     con = connect()
     try:
         rows = con.execute(
             "SELECT type_id FROM type_trends WHERE vol_30d_avg >= ? ORDER BY mom_pct DESC LIMIT ?",
             (MIN_DAILY_VOL, limit),
         ).fetchall()
+
+        bid = build_started("recommendations", {"candidates": len(rows)})
+        build_progress(bid, 25, "filter", f"candidates {len(rows)}")
+
         results = []
-        for (type_id,) in rows:
+        for i, (type_id,) in enumerate(rows, start=1):
             rec = evaluate_type(type_id)
             if not rec:
                 continue
@@ -40,11 +53,22 @@ def build_recommendations(limit=50):
                 ),
             )
             results.append(rec)
+            if verbose and len(rows):
+                pct = 25 + int(i / len(rows) * 50)
+                build_progress(bid, pct, "score", f"{i}/{len(rows)}")
+
+        build_progress(bid, 75, "score", f"{len(results)} scored")
+        build_progress(bid, 90, "upsert", f"{len(results)} ready")
         con.commit()
+        build_progress(bid, 100, "upsert", f"{len(results)} rows")
+        ms = int((time.time() - t0) * 1000)
         record_job("recommendations", True, {"count": len(results)})
+        build_finished(bid, True, rows=len(results), ms=ms)
         return results
     except Exception as e:
+        ms = int((time.time() - t0) * 1000)
         record_job("recommendations", False, {"error": str(e)})
+        build_finished(bid, False, rows=0, ms=ms, error=str(e))
         raise
     finally:
         con.close()

--- a/app/service.py
+++ b/app/service.py
@@ -756,9 +756,15 @@ def recompute_valuations():
 
 
 @app.post("/jobs/{name}/run")
-def run_job(name: str):
+def run_job(name: str, verbose: bool = False):
+    """Run a background job immediately.
+
+    The optional ``verbose`` flag triggers additional event chatter so that
+    testers can observe progress updates even in fast unit-test scenarios.
+    """
+
     if name == "recommendations":
-        recs = build_recommendations()
+        recs = build_recommendations(verbose=verbose)
         return {"count": len(recs)}
     if name == "scheduler_tick":
         run_tick()


### PR DESCRIPTION
## Summary
- instrument recommendations build with structured build events
- allow `run_job` endpoint to run in verbose mode for QA

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68afde6cf1c483239256ed24d8e9345b