### PR TITLE
Fix Runway event typing

### DIFF
--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1,11 +1,19 @@
 export const API_BASE = 'http://localhost:8000';
 
+export interface StatusLog {
+  type: string;
+  runId?: string;
+  level?: string;
+  message?: string;
+}
+
 export interface StatusSnapshot {
   inflight?: unknown[];
   last_runs?: { job: string; ok: boolean; ts?: string; ms?: number }[];
   counts?: Record<string, number>;
   esi?: { remain?: number; reset?: number };
   queue?: Record<string, number>;
+  logs?: StatusLog[];
 }
 
 export async function getStatus(): Promise<StatusSnapshot> {


### PR DESCRIPTION
## Summary
- add StatusLog to StatusSnapshot and include logs
- type event stream with RunwayEvent and cleanup WebSocket handling
- strongly type Runway page view model

## Testing
- `npm run lint`
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afde882f088323aa6d2ba9fcdf1eb4