### PR TITLE
feat: centralize event helpers

### DIFF
--- a/app/emit.py
+++ b/app/emit.py
@@ -88,6 +88,19 @@ def build_progress(buildId: str, progress: int, stage: str = "", detail: str = "
     )
 
 
+# Resource / status events -----------------------------------------------------------
+
+
+def esi_status(remain: int, reset: int) -> None:
+    """Emit an event capturing current ESI error limit headers."""
+    emit_sync({"type": "esi", "remain": remain, "reset": reset})
+
+
+def queue_event(depth: dict[str, int]) -> None:
+    """Emit queue depth information by priority class."""
+    emit_sync({"type": "queue", "depth": depth})
+
+
 def build_finished(buildId: str, ok: bool, rows: int = 0, ms: int = 0, error: str | None = None) -> None:
     emit_sync(
         {

--- a/app/esi.py
+++ b/app/esi.py
@@ -4,7 +4,7 @@ import requests
 
 from .config import DATASOURCE
 from .status import STATUS
-from .emit import emit_sync
+from .emit import esi_status
 
 BASE = "https://esi.evetech.net/latest"
 HEADERS = {"Accept": "application/json"}
@@ -32,7 +32,7 @@ def get(url, params=None, etag=None, token=None):
         r.headers.get("X-ESI-Error-Limit-Reset", ERROR_LIMIT_RESET)
     )
     STATUS["esi"] = {"remain": ERROR_LIMIT_REMAIN, "reset": ERROR_LIMIT_RESET}
-    emit_sync({"type": "esi", "remain": ERROR_LIMIT_REMAIN, "reset": ERROR_LIMIT_RESET})
+    esi_status(ERROR_LIMIT_REMAIN, ERROR_LIMIT_RESET)
     logger.info("response %s %s", r.status_code, r.headers.get("X-Pages"))
     if r.status_code == 304:
         return None, r.headers, 304

--- a/app/jobs.py
+++ b/app/jobs.py
@@ -18,7 +18,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from . import db, esi
 from .status import STATUS
-from .emit import emit_sync, job_started, job_finished
+from .emit import job_started, job_finished, queue_event
 
 # Public state for status reporting -------------------------------------------------
 
@@ -48,7 +48,7 @@ def _refresh_snapshot() -> None:
     JOB_QUEUE[:] = [job.name for _, _, job in sorted(_queue)]
     depth = queue_depth()
     STATUS["queue"] = depth
-    emit_sync({"type": "queue", "depth": depth})
+    queue_event(depth)
 
 
 def enqueue(name: str, func: Callable[..., Any], priority: str = "P2", *args, **kwargs) -> None:

--- a/ui/src/pages/Runway.tsx
+++ b/ui/src/pages/Runway.tsx
@@ -49,7 +49,8 @@ function useRunwayVM(events: RunwayEvent[]) {
 
 export default function Runway() {
   const { connected, events } = useEventStream();
-  const { inflightList, recentBuilds, esi, queue, logs } = useRunwayVM(events);
+  const { inflightList, recentJobs, recentBuilds, esi, queue, logs } =
+    useRunwayVM(events);
   const dotStyle: React.CSSProperties = {
     width: 10,
     height: 10,
@@ -94,13 +95,21 @@ export default function Runway() {
           </span>
         ))}
       </div>
+      <h3>Recent Jobs</h3>
+      <ul>
+        {recentJobs.map((j) => (
+          <li key={j.runId} title={j.detail}>
+            <strong>{j.job}</strong> {j.ok ? "ok" : "fail"} {j.ms}ms {trunc(j.detail ?? "")}
+          </li>
+        ))}
+      </ul>
       <h3>Recent Builds</h3>
       <ul>
-          {recentBuilds.map((b) => (
-            <li key={b.buildId} title={b.detail}>
-              <strong>{b.job}</strong> {b.progress}% {b.stage} {trunc(b.detail ?? "")}
-            </li>
-          ))}
+        {recentBuilds.map((b) => (
+          <li key={b.buildId} title={b.detail}>
+            <strong>{b.job}</strong> {b.progress}% {b.stage} {trunc(b.detail ?? "")}
+          </li>
+        ))}
       </ul>
       <h3>Logs</h3>
       <ul>


### PR DESCRIPTION
## Summary
- add dedicated emit helpers for queue and ESI status events
- surface recent job completions in Runway panel
- wire backend modules to use new helpers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afe07411188323a730d893edf8ea27