### PR TITLE
Emit detailed scheduler tick events

### DIFF
--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -1,6 +1,5 @@
 import time
 import logging
-import uuid
 from concurrent.futures import ThreadPoolExecutor
 from threading import Lock
 from .db import connect
@@ -65,13 +64,16 @@ def _select_workers(target: int) -> int:
 
 
 def run_tick(max_calls: int = 800, workers: int = 6) -> None:
+    """Refresh due market snapshots and emit structured progress events."""
+
     logger.info("Running scheduler tick")
     workers = _select_workers(workers)
+
     con = connect()
     try:
         due = con.execute(
             """
-            SELECT type_id FROM type_status
+            SELECT type_id, tier FROM type_status
             WHERE next_refresh IS NULL OR next_refresh <= datetime('now')
             ORDER BY COALESCE(last_orders_refresh,'1970-01-01') ASC
             LIMIT ?
@@ -83,38 +85,81 @@ def run_tick(max_calls: int = 800, workers: int = 6) -> None:
 
     count = len(due)
     logger.info("%s types due for refresh", count)
-    run_id = job_started("scheduler_tick", {"total": count})
+
+    tier_counts: dict[str, int] = {"A": 0, "B": 0, "C": 0, "D": 0}
+    for _, tier in due:
+        if tier in tier_counts:
+            tier_counts[tier] += 1
+
+    rid = job_started("scheduler_tick", {"total": count})
+    emit_sync(
+        {
+            "job": "scheduler_tick",
+            "runId": rid,
+            "phase": "start",
+            "tiers": tier_counts,
+            "selected": count,
+            "workers": workers,
+            "expected_pages": count,
+        }
+    )
 
     t0 = time.time()
     lock = Lock()
     completed = 0
+    errors = 0
 
     def _run(tid: int) -> None:
-        nonlocal completed
-        c = connect()
+        nonlocal completed, errors
         try:
-            refresh_one(c, tid)
-            c.commit()
+            c = connect()
+            try:
+                refresh_one(c, tid)
+                c.commit()
+            finally:
+                c.close()
+        except Exception:
+            errors += 1
         finally:
-            c.close()
-        with lock:
-            completed += 1
-            pct = int(completed / count * 100) if count else 100
-            job_progress(run_id, pct, f"type {tid}")
+            with lock:
+                completed += 1
+                pct = int(completed / count * 100) if count else 100
+                job_progress(rid, pct, f"type {tid}")
+                emit_sync(
+                    {
+                        "job": "scheduler_tick",
+                        "runId": rid,
+                        "phase": "progress",
+                        "done": completed,
+                        "total": count,
+                        "detail": f"type {tid}",
+                    }
+                )
 
     try:
         with ThreadPoolExecutor(max_workers=workers) as pool:
-            for (tid,) in due:
+            for tid, _ in due:
                 pool.submit(_run, tid)
             pool.shutdown(wait=True)
         record_job("scheduler_tick", True, {"refreshed": count})
     except Exception as e:
         record_job("scheduler_tick", False, {"error": str(e)})
-        job_finished(run_id, ok=False, error=str(e))
+        emit_sync(
+            {
+                "job": "scheduler_tick",
+                "runId": rid,
+                "phase": "finish",
+                "items_written": completed,
+                "unique_types_touched": completed,
+                "median_snapshot_age_ms": 0,
+                "errors": errors or 1,
+                "ms": int((time.time() - t0) * 1000),
+            }
+        )
+        job_finished(rid, ok=False, error=str(e))
         raise
     else:
         ms = int((time.time() - t0) * 1000)
-        # update recent type refresh counts for status snapshot
         con2 = connect()
         try:
             last10 = con2.execute(
@@ -123,8 +168,32 @@ def run_tick(max_calls: int = 800, workers: int = 6) -> None:
             last60 = con2.execute(
                 "SELECT COUNT(*) FROM type_status WHERE last_orders_refresh >= datetime('now', '-60 minutes')"
             ).fetchone()[0]
+            ages = [
+                row[0]
+                for row in con2.execute(
+                    "SELECT (strftime('%s','now') - strftime('%s', last_orders_refresh)) * 1000 FROM type_status WHERE last_orders_refresh IS NOT NULL"
+                ).fetchall()
+            ]
         finally:
             con2.close()
+
+        median_age = 0
+        if ages:
+            ages.sort()
+            median_age = ages[len(ages) // 2]
+
         STATUS["counts"] = {"types_10m": last10, "types_1h": last60}
         emit_sync({"type": "counts", "counts": STATUS["counts"]})
-        job_finished(run_id, ok=True, items=count, ms=ms)
+        emit_sync(
+            {
+                "job": "scheduler_tick",
+                "runId": rid,
+                "phase": "finish",
+                "items_written": completed,
+                "unique_types_touched": completed,
+                "median_snapshot_age_ms": median_age,
+                "errors": errors,
+                "ms": ms,
+            }
+        )
+        job_finished(rid, ok=True, items=count, ms=ms)

--- a/tests/test_scheduler_tick_events.py
+++ b/tests/test_scheduler_tick_events.py
@@ -1,0 +1,66 @@
+from datetime import datetime
+import pathlib, sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from app import db, scheduler
+
+
+def _fake_refresh_one(con, tid):
+    ts = datetime.utcnow().isoformat()
+    con.execute(
+        """
+        INSERT OR REPLACE INTO market_snapshots
+        (ts_utc, type_id, best_bid, best_ask, bid_count, ask_count, jita_bid_units, jita_ask_units)
+        VALUES (?,?,?,?,?,?,?,?)
+        """,
+        (ts, tid, None, None, 0, 0, 0, 0),
+    )
+    con.execute(
+        """
+        UPDATE type_status SET last_orders_refresh=?, next_refresh=datetime('now', '+60 minutes')
+        WHERE type_id=?
+        """,
+        (ts, tid),
+    )
+
+
+def test_scheduler_tick_emits_structured_events(tmp_path, monkeypatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "test.sqlite3")
+    db.init_db()
+    con = db.connect()
+    try:
+        for tid, tier in [(1, "A"), (2, "B"), (3, "C")]:
+            con.execute(
+                "INSERT INTO type_status(type_id, tier, update_interval_min) VALUES (?,?,0)",
+                (tid, tier),
+            )
+        con.commit()
+    finally:
+        con.close()
+
+    events = []
+
+    async def fake_broadcast(evt):
+        events.append(evt)
+
+    monkeypatch.setattr(scheduler, "refresh_one", _fake_refresh_one)
+    monkeypatch.setattr("app.emit.broadcast", fake_broadcast)
+
+    scheduler.run_tick(max_calls=10, workers=1)
+
+    tick_events = [e for e in events if e.get("job") == "scheduler_tick"]
+
+    start = next(e for e in tick_events if e.get("phase") == "start")
+    assert start["tiers"] == {"A": 1, "B": 1, "C": 1, "D": 0}
+    assert start["selected"] == 3
+
+    progresses = [e for e in tick_events if e.get("phase") == "progress"]
+    assert progresses[-1]["done"] == 3
+    assert progresses[-1]["total"] == 3
+
+    finish = next(e for e in tick_events if e.get("phase") == "finish")
+    assert finish["items_written"] == 3
+    assert finish["unique_types_touched"] == 3
+    assert finish["errors"] == 0
+


### PR DESCRIPTION
## Summary
- emit structured start, progress, and finish events during scheduler ticks
- cover scheduler tick event stream with regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afe26ca32483238844f98008265c83