### PR TITLE
feat: add recommendations build dry-run endpoint

### DIFF
--- a/app/recommender.py
+++ b/app/recommender.py
@@ -2,13 +2,23 @@ import json
 import time
 from .db import connect
 from .market import evaluate_type
-from .config import MIN_DAILY_VOL, STATION_ID
+from .config import (
+    MIN_DAILY_VOL,
+    STATION_ID,
+    REC_FRESH_MS,
+    MOM_THRESHOLD,
+)
 from .jobs import record_job
 from .emit import build_started, build_progress, build_finished
 
 
-def build_recommendations(limit: int = 50, verbose: bool = False):
+def build_recommendations(
+    limit: int = 50, verbose: bool = False, dry_run: bool = False
+):
     """Populate the recommendations table with top candidates.
+
+    When ``dry_run`` is ``True`` the database is left untouched and a summary
+    of pipeline counts is returned instead of inserted rows.
 
     Emits ``build_*`` events so the UI can surface progress for the
     recommendations build. When ``verbose`` is ``True`` extra progress
@@ -19,55 +29,105 @@ def build_recommendations(limit: int = 50, verbose: bool = False):
     con = connect()
     try:
         rows = con.execute(
-            "SELECT type_id FROM type_trends WHERE vol_30d_avg >= ? ORDER BY mom_pct DESC LIMIT ?",
+            "SELECT type_id, mom_pct FROM type_trends WHERE vol_30d_avg >= ? ORDER BY mom_pct DESC LIMIT ?",
             (MIN_DAILY_VOL, limit),
         ).fetchall()
 
-        bid = build_started("recommendations", {"candidates": len(rows)})
-        build_progress(bid, 25, "filter", f"candidates {len(rows)}")
+        candidates = len(rows)
+        bid = build_started(
+            "recommendations", {"fresh_ms": REC_FRESH_MS, "candidates": candidates}
+        )
+        build_progress(bid, 10, "collect", f"candidates={candidates}")
+
+        # freshness gate ----------------------------------------------------
+        threshold = f"-{REC_FRESH_MS // 1000} seconds"
+        fresh_ids = {
+            tid
+            for (tid,) in con.execute(
+                "SELECT DISTINCT type_id FROM market_snapshots WHERE ts_utc >= datetime('now', ?)",
+                (threshold,),
+            ).fetchall()
+        }
+        fresh_pass = sum(1 for tid, _ in rows if tid in fresh_ids)
+        build_progress(
+            bid,
+            30,
+            "freshness",
+            f"pass={fresh_pass} fail={candidates - fresh_pass}",
+        )
+
+        # volume and MoM gates ---------------------------------------------
+        vol_pass = candidates  # initial query already enforces volume
+        build_progress(
+            bid,
+            45,
+            "volume",
+            f"min_daily_vol={MIN_DAILY_VOL} pass={vol_pass} drop=0",
+        )
+        mom_pass = sum(1 for _, m in rows if m is not None and m >= MOM_THRESHOLD)
+        build_progress(
+            bid,
+            60,
+            "mom",
+            f"min_mom={MOM_THRESHOLD} pass={mom_pass} drop={candidates - mom_pass}",
+        )
 
         results = []
-        for i, (type_id,) in enumerate(rows, start=1):
+        for i, (type_id, _) in enumerate(rows, start=1):
             rec = evaluate_type(type_id)
             if not rec:
                 continue
-            con.execute(
-                """
-                INSERT INTO recommendations
-                (type_id, station_id, ts_utc, net_pct, uplift_mom, daily_capacity, rationale_json)
-                VALUES (?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?)
-                ON CONFLICT(type_id, station_id) DO UPDATE SET
-                    ts_utc = CURRENT_TIMESTAMP,
-                    net_pct = excluded.net_pct,
-                    uplift_mom = excluded.uplift_mom,
-                    daily_capacity = excluded.daily_capacity,
-                    rationale_json = excluded.rationale_json
-                """,
-                (
-                    rec["type_id"],
-                    STATION_ID,
-                    rec["net_spread_pct"],
-                    rec["uplift_mom"],
-                    rec["daily_isk_capacity"],
-                    json.dumps(rec),
-                ),
-            )
             results.append(rec)
-            if verbose and len(rows):
-                pct = 25 + int(i / len(rows) * 50)
-                build_progress(bid, pct, "score", f"{i}/{len(rows)}")
+            if not dry_run:
+                con.execute(
+                    """
+                    INSERT INTO recommendations
+                    (type_id, station_id, ts_utc, net_pct, uplift_mom, daily_capacity, rationale_json)
+                    VALUES (?, ?, CURRENT_TIMESTAMP, ?, ?, ?, ?)
+                    ON CONFLICT(type_id, station_id) DO UPDATE SET
+                        ts_utc = CURRENT_TIMESTAMP,
+                        net_pct = excluded.net_pct,
+                        uplift_mom = excluded.uplift_mom,
+                        daily_capacity = excluded.daily_capacity,
+                        rationale_json = excluded.rationale_json
+                    """,
+                    (
+                        rec["type_id"],
+                        STATION_ID,
+                        rec["net_spread_pct"],
+                        rec["uplift_mom"],
+                        rec["daily_isk_capacity"],
+                        json.dumps(rec),
+                    ),
+                )
+            if verbose and mom_pass:
+                pct = 60 + int(i / mom_pass * 30)
+                build_progress(bid, pct, "score", f"scored={i}")
 
-        build_progress(bid, 75, "score", f"{len(results)} scored")
-        build_progress(bid, 90, "upsert", f"{len(results)} ready")
-        con.commit()
-        build_progress(bid, 100, "upsert", f"{len(results)} rows")
+        scored = len(results)
+        build_progress(bid, 90, "score", f"scored={scored}")
         ms = int((time.time() - t0) * 1000)
-        record_job("recommendations", True, {"count": len(results)})
-        build_finished(bid, True, rows=len(results), ms=ms)
+
+        if dry_run:
+            build_finished(bid, True, rows=scored, ms=ms)
+            return {
+                "candidates": candidates,
+                "fresh_pass": fresh_pass,
+                "vol_pass": vol_pass,
+                "mom_pass": mom_pass,
+                "scored": scored,
+                "would_write": scored,
+            }
+
+        build_progress(bid, 100, "upsert", f"{scored} rows")
+        con.commit()
+        record_job("recommendations", True, {"count": scored})
+        build_finished(bid, True, rows=scored, ms=ms)
         return results
     except Exception as e:
         ms = int((time.time() - t0) * 1000)
-        record_job("recommendations", False, {"error": str(e)})
+        if not dry_run:
+            record_job("recommendations", False, {"error": str(e)})
         build_finished(bid, False, rows=0, ms=ms, error=str(e))
         raise
     finally:

--- a/app/service.py
+++ b/app/service.py
@@ -755,6 +755,15 @@ def recompute_valuations():
     return {"count": count}
 
 
+@app.post("/recommendations/build")
+def recommendations_build(dry_run: bool = False, verbose: bool = False):
+    """Trigger a recommendations build or return dry-run counts."""
+    res = build_recommendations(verbose=verbose, dry_run=dry_run)
+    if dry_run:
+        return res
+    return {"rows": len(res)}
+
+
 @app.post("/jobs/{name}/run")
 def run_job(name: str, verbose: bool = False):
     """Run a background job immediately.

--- a/tests/test_recommendations_build_dry_run.py
+++ b/tests/test_recommendations_build_dry_run.py
@@ -1,0 +1,73 @@
+from fastapi.testclient import TestClient
+from datetime import datetime, timedelta
+from pathlib import Path
+import sys
+
+# Ensure app package importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app import service, db, config
+from app import recommender
+
+
+def test_recommendations_build_dry_run(tmp_path, monkeypatch):
+    # Set up isolated DB
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "test.sqlite3")
+    db.init_db()
+    con = db.connect()
+    try:
+        # populate type_trends with three candidates
+        con.executemany(
+            "INSERT INTO type_trends(type_id, vol_30d_avg, mom_pct) VALUES(?,?,?)",
+            [
+                (1, 150, 0.15),
+                (2, 200, 0.20),
+                (3, 180, 0.05),
+            ],
+        )
+        now = datetime.utcnow()
+        recent = (now - timedelta(minutes=5)).strftime("%Y-%m-%d %H:%M:%S")
+        old = (now - timedelta(hours=1)).strftime("%Y-%m-%d %H:%M:%S")
+        con.execute(
+            "INSERT INTO market_snapshots(ts_utc, type_id, best_bid, best_ask, bid_count, ask_count, jita_bid_units, jita_ask_units) VALUES (?,?,?,?,?,?,?,?)",
+            (recent, 1, 10, 12, 0, 0, 0, 0),
+        )
+        con.execute(
+            "INSERT INTO market_snapshots(ts_utc, type_id, best_bid, best_ask, bid_count, ask_count, jita_bid_units, jita_ask_units) VALUES (?,?,?,?,?,?,?,?)",
+            (old, 2, 11, 13, 0, 0, 0, 0),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+    # stub evaluate_type to avoid network
+    def fake_eval(tid):
+        if tid in (1, 2):
+            return {
+                "type_id": tid,
+                "net_spread_pct": 0.05,
+                "uplift_mom": 0.2,
+                "daily_isk_capacity": 1000,
+            }
+        return None
+
+    monkeypatch.setattr(recommender, "evaluate_type", fake_eval)
+
+    client = TestClient(service.app)
+    resp = client.post("/recommendations/build?dry_run=true")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["candidates"] == 3
+    assert data["fresh_pass"] == 1
+    assert data["vol_pass"] == 3
+    assert data["mom_pass"] == 2
+    assert data["scored"] == 2
+    assert data["would_write"] == 2
+
+    # ensure no rows written
+    con = db.connect()
+    try:
+        cnt = con.execute("SELECT COUNT(*) FROM recommendations").fetchone()[0]
+    finally:
+        con.close()
+    assert cnt == 0

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -58,6 +58,18 @@ export async function runJob(name: string, verbose = false) {
   return res.json();
 }
 
+export async function buildRecommendations(
+  dryRun = false,
+  verbose = false,
+) {
+  const url = new URL(`${API_BASE}/recommendations/build`);
+  if (dryRun) url.searchParams.set('dry_run', 'true');
+  if (verbose) url.searchParams.set('verbose', 'true');
+  const res = await fetch(url.toString(), { method: 'POST' });
+  if (!res.ok) throw new Error('Failed to build recommendations');
+  return res.json();
+}
+
 export interface RecParams {
   limit?: number;
   offset?: number;

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -1,5 +1,14 @@
 import { useEffect, useState } from 'react';
-import { API_BASE, getStatus, runJob, type StatusSnapshot, getWatchlist, getCoverage, type Coverage } from '../api';
+import {
+  API_BASE,
+  getStatus,
+  runJob,
+  type StatusSnapshot,
+  getWatchlist,
+  getCoverage,
+  type Coverage,
+  buildRecommendations,
+} from '../api';
 import Spinner from '../Spinner';
 import ErrorBanner from '../ErrorBanner';
 import TypeName from '../TypeName';
@@ -69,6 +78,22 @@ export default function Dashboard() {
     }
   }
 
+  async function buildRecs() {
+    setLoading(true);
+    try {
+      await buildRecommendations();
+      await refresh();
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        setError(e.message);
+      } else {
+        setError(String(e));
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
   useEffect(() => {
     refresh();
     const wsUrl = API_BASE.replace('http', 'ws') + '/ws';
@@ -121,7 +146,7 @@ export default function Dashboard() {
         </p>
       )}
       <button disabled={loading} onClick={() => run('scheduler_tick')}>Run Scheduler</button>
-      <button disabled={loading} onClick={() => run('recommendations')}>Build Recommendations</button>
+      <button disabled={loading} onClick={buildRecs}>Build Recommendations</button>
       <h3>Recent Jobs</h3>
       <ul>
         {jobs.map(j => (


### PR DESCRIPTION
## Summary
- allow running the recommendation builder in dry-run mode with detailed counts
- expose POST /recommendations/build API and wire dashboard to use it
- cover dry-run behaviour with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afe3e667248323b11a68e1966ed2b8