### PR TITLE
feat: track pending job queue

### DIFF
--- a/app/emit.py
+++ b/app/emit.py
@@ -27,8 +27,18 @@ def emit_sync(evt: dict) -> None:
 
 # Job event helpers ------------------------------------------------------------------
 
-def job_started(job: str, meta: Optional[dict] = None) -> str:
-    rid = run_id()
+
+def job_started(
+    job: str, meta: Optional[dict] = None, runId: Optional[str] = None
+) -> str:
+    """Emit a ``job_started`` event and return the run identifier.
+
+    When ``runId`` is provided the caller controls the identifier allowing
+    correlation with earlier ``jobs`` queue events. Otherwise a new identifier
+    is generated.
+    """
+
+    rid = runId or run_id()
     emit_sync({"type": "job_started", "job": job, "runId": rid, "meta": meta or {}})
     return rid
 
@@ -99,6 +109,11 @@ def esi_status(remain: int, reset: int) -> None:
 def queue_event(depth: dict[str, int]) -> None:
     """Emit queue depth information by priority class."""
     emit_sync({"type": "queue", "depth": depth})
+
+
+def jobs_event(pending: list[dict]) -> None:
+    """Emit a snapshot of pending jobs in the internal queue."""
+    emit_sync({"type": "jobs", "pending": pending})
 
 
 def build_finished(buildId: str, ok: bool, rows: int = 0, ms: int = 0, error: str | None = None) -> None:

--- a/app/status.py
+++ b/app/status.py
@@ -12,6 +12,7 @@ STATUS: Dict[str, Any] = {
     "queue": {},
     "logs": [],
     "counts": {},
+    "pending": [],
 }
 
 
@@ -63,6 +64,8 @@ def update_status(evt: Dict[str, Any]) -> None:
         STATUS["esi"] = {"remain": evt.get("remain"), "reset": evt.get("reset")}
     elif t == "queue":
         STATUS["queue"] = evt.get("depth", {})
+    elif t == "jobs":
+        STATUS["pending"] = evt.get("pending", [])
 
 
 @status_router.get("/status")
@@ -73,6 +76,7 @@ def get_status() -> Dict[str, Any]:
         "last_runs": STATUS.get("last_runs", []),
         "esi": STATUS.get("esi", {}),
         "queue": STATUS.get("queue", {}),
+        "pending": STATUS.get("pending", []),
         "logs": STATUS.get("logs", []),
         "counts": STATUS.get("counts", {}),
     }

--- a/tests/test_jobs_pending_events.py
+++ b/tests/test_jobs_pending_events.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+# ensure app is importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app import jobs, service
+from app.status import STATUS
+
+def dummy():
+    pass
+
+def test_jobs_pending_list_updates(monkeypatch):
+    jobs.clear_queue()
+    STATUS["pending"] = []
+    STATUS["queue"] = {}
+
+    jobs.enqueue("a", dummy, priority="P1")
+    jobs.enqueue("b", dummy, priority="P3")
+
+    client = TestClient(service.app)
+    resp = client.get("/status")
+    data = resp.json()
+    assert data["queue"]["P1"] == 1
+    assert data["queue"]["P3"] == 1
+    assert [p["job"] for p in data["pending"]] == ["b", "a"]
+
+    jobs.run_next_job()
+
+    resp = client.get("/status")
+    data = resp.json()
+    assert [p["job"] for p in data["pending"]] == ["b"]


### PR DESCRIPTION
## Summary
- broadcast pending job ledger over jobs events
- persist run identifiers for queued jobs and expose pending list via /status
- test queue ledger reporting

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afe4ec7f308323840850aca2a7810d