### PR TITLE
Add coverage endpoint and Runway panel with queue visibility

### DIFF
--- a/tests/test_service_coverage.py
+++ b/tests/test_service_coverage.py
@@ -1,0 +1,40 @@
+from fastapi.testclient import TestClient
+from datetime import datetime, timedelta
+import sys
+from pathlib import Path
+
+# Ensure 'app' package importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app import service, db
+
+
+def test_coverage_endpoint(tmp_path, monkeypatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "test.sqlite3")
+    db.init_db()
+    con = db.connect()
+    try:
+        now = datetime.utcnow()
+        fmt = "%Y-%m-%d %H:%M:%S"
+        recent = (now - timedelta(minutes=5)).strftime(fmt)
+        old = (now - timedelta(minutes=20)).strftime(fmt)
+        con.execute(
+            "INSERT INTO market_snapshots(ts_utc, type_id, best_bid, best_ask, bid_count, ask_count, jita_bid_units, jita_ask_units) VALUES (?,?,?,?,?,?,?,?)",
+            (recent, 1, 10, 12, 0, 0, 0, 0),
+        )
+        con.execute(
+            "INSERT INTO market_snapshots(ts_utc, type_id, best_bid, best_ask, bid_count, ask_count, jita_bid_units, jita_ask_units) VALUES (?,?,?,?,?,?,?,?)",
+            (old, 2, 11, 13, 0, 0, 0, 0),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+    client = TestClient(service.app)
+    resp = client.get("/coverage")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["types_indexed"] == 2
+    assert data["books_10m"] == 1
+    assert data["distinct_types_24h"] == 2
+    assert data["median_age_s"] >= 0

--- a/ui/src/RunwayPanel.tsx
+++ b/ui/src/RunwayPanel.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import type { RunwayEvent } from "./useEventStream";
+import { useRunwayVM } from "./runwayVM";
+
+interface Props {
+  connected: boolean;
+  events: RunwayEvent[];
+}
+
+export default function RunwayPanel({ connected, events }: Props) {
+  const { inflightList, recentJobs, recentBuilds, pending, esi, queue, logs } =
+    useRunwayVM(events);
+  const dotStyle: React.CSSProperties = {
+    width: 10,
+    height: 10,
+    borderRadius: "50%",
+    backgroundColor: connected ? "green" : "red",
+    display: "inline-block",
+    marginRight: 8,
+  };
+  const trunc = (s: string) => (s && s.length > 80 ? s.slice(0, 80) + "…" : s);
+
+  return (
+    <div>
+      <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+        <span style={dotStyle}></span>
+        <span>
+          ESI remain: {esi.remain ?? ""} reset: {esi.reset ?? ""}
+        </span>
+      </div>
+      <h3>Now Running</h3>
+      <ul>
+        {inflightList.length === 0 && <li>None</li>}
+        {inflightList.map((j) => (
+          <li key={j.runId} title={j.detail}>
+            <strong>{j.job}</strong> {j.progress}% {trunc(j.detail ?? "")}
+          </li>
+        ))}
+      </ul>
+      <h3>Pending Queue</h3>
+      <ul>
+        {pending.length === 0 && <li>None</li>}
+        {pending.map((p) => (
+          <li key={p.runId}>
+            {p.job} queued {p.queued_at}
+          </li>
+        ))}
+      </ul>
+      <h3>Queue Depth</h3>
+      <div>
+        {Object.entries(queue).map(([k, v]) => (
+          <span
+            key={k}
+            style={{
+              marginRight: "8px",
+              padding: "2px 4px",
+              border: "1px solid #ccc",
+              borderRadius: "4px",
+            }}
+          >
+            {k}:{String(v)}
+          </span>
+        ))}
+      </div>
+      <h3>Recent Jobs</h3>
+      <ul>
+        {recentJobs.map((j) => (
+          <li key={j.runId} title={j.detail}>
+            <strong>{j.job}</strong> {j.ok ? "ok" : "fail"} {j.ms}ms {trunc(j.detail ?? "")}
+          </li>
+        ))}
+      </ul>
+      <h3>Recent Builds</h3>
+      <ul>
+        {recentBuilds.map((b) => (
+          <li key={b.buildId} title={b.detail}>
+            <strong>{b.job}</strong> {b.progress}% {b.stage} {trunc(b.detail ?? "")}
+          </li>
+        ))}
+      </ul>
+      <h3>Logs</h3>
+      <ul>
+        {logs.slice(-50).map((l, i) => (
+          <li key={i} title={l.message}>
+            {l.level}: {trunc(l.message ?? "")}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -24,12 +24,13 @@ export async function getStatus(): Promise<StatusSnapshot> {
 
 export interface Coverage {
   types_indexed: number;
-  books_last_10m: number;
-  median_snapshot_age_ms: number;
+  books_10m: number;
+  median_age_s: number;
+  distinct_types_24h: number;
 }
 
 export async function getCoverage(): Promise<Coverage> {
-  const res = await fetch(`${API_BASE}/inventory/coverage`);
+  const res = await fetch(`${API_BASE}/coverage`);
   if (!res.ok) throw new Error('Failed to fetch coverage');
   return res.json();
 }

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -1,50 +1,28 @@
 import { useEffect, useState } from 'react';
 import {
-  API_BASE,
-  getStatus,
   runJob,
-  type StatusSnapshot,
   getWatchlist,
   getCoverage,
   type Coverage,
   buildRecommendations,
 } from '../api';
+import { useEventStream } from '../useEventStream';
+import RunwayPanel from '../RunwayPanel';
+import { useRunwayVM } from '../runwayVM';
 import Spinner from '../Spinner';
 import ErrorBanner from '../ErrorBanner';
 import TypeName from '../TypeName';
 
-interface JobRec {
-  job: string;
-  ts?: string;
-  ok: boolean;
-  ms?: number;
-}
-
-interface InflightJob {
-  id: number;
-  job: string;
-  detail?: string;
-  progress: number;
-}
-
 export default function Dashboard() {
-  const [jobs, setJobs] = useState<JobRec[]>([]);
-  const [esi, setEsi] = useState<StatusSnapshot['esi'] | null>(null);
+  const { connected, events } = useEventStream();
+  const { inflightList, pending } = useRunwayVM(events);
   const [error, setError] = useState<string>('');
   const [loading, setLoading] = useState(false);
   const [watchlist, setWatchlist] = useState<number[]>([]);
   const [coverage, setCoverage] = useState<Coverage | null>(null);
-  const [inflight, setInflight] = useState<InflightJob[]>([]);
-  const [queue, setQueue] = useState<Record<string, number>>({});
-
   async function refresh() {
     setLoading(true);
     try {
-      const data = await getStatus();
-      setJobs(data.last_runs || []);
-      setEsi(data.esi);
-      setInflight((data.inflight as InflightJob[]) || []);
-      setQueue(data.queue || {});
       const wl = await getWatchlist();
       const ids: number[] = (wl.items || []).map((i: { type_id: number }) => i.type_id);
       setWatchlist(ids);
@@ -96,63 +74,26 @@ export default function Dashboard() {
 
   useEffect(() => {
     refresh();
-    const wsUrl = API_BASE.replace('http', 'ws') + '/ws';
-    const ws = new WebSocket(wsUrl);
-    ws.onmessage = (ev) => {
-      try {
-        const evt = JSON.parse(ev.data);
-        if (evt.type === 'job_started') {
-          setInflight((prev) => [...prev, { id: evt.id, job: evt.job, detail: evt.meta?.detail, progress: 0 }]);
-        } else if (evt.type === 'job_progress') {
-          setInflight((prev) => prev.map((j) => (j.id === evt.id ? { ...j, progress: evt.progress, detail: evt.detail } : j)));
-        } else if (evt.type === 'job_finished') {
-          setInflight((prev) => prev.filter((j) => j.id !== evt.id));
-          setJobs((prev) => [{ job: evt.job, ts: new Date().toISOString(), ok: evt.ok, ms: evt.ms }, ...prev]);
-        } else if (evt.type === 'esi') {
-          setEsi({ remain: evt.remain, reset: evt.reset });
-        } else if (evt.type === 'queue') {
-          setQueue(evt.depth || {});
-        }
-      } catch {
-        // ignore malformed events
-      }
-    };
-    return () => ws.close();
   }, []);
+
+  const recRunning = inflightList.some((j) => j.job === 'recommendations');
+  const recPending = pending.some((p) => p.job === 'recommendations');
 
   return (
     <div>
       <h2>Dashboard</h2>
       <ErrorBanner message={error} />
       {loading && <Spinner />}
-      {esi && (<p>ESI Error Limit: {esi.remain} (reset {esi.reset}s)</p>)}
-      {inflight.length > 0 && (
-        <div>
-          <h4>Now Running</h4>
-          {inflight.map(j => (
-            <div key={j.id}>{j.job} {j.progress ? `${j.progress}%` : ''} {j.detail}</div>
-          ))}
-        </div>
-      )}
-      {Object.keys(queue).length > 0 && (
-        <p>
-          Queue depth: {Object.entries(queue).map(([k,v]) => `${k}:${v}`).join(' · ')}
-        </p>
-      )}
+      <RunwayPanel connected={connected} events={events} />
       {coverage && (
         <p>
-          Types indexed: {coverage.types_indexed} · Books 10m: {coverage.books_last_10m} ·
-          Median age: {Math.round(coverage.median_snapshot_age_ms / 1000)}s
+          Types indexed: {coverage.types_indexed} · Books 10m: {coverage.books_10m} ·
+          Median age: {coverage.median_age_s}s · 24h types: {coverage.distinct_types_24h}
         </p>
       )}
       <button disabled={loading} onClick={() => run('scheduler_tick')}>Run Scheduler</button>
-      <button disabled={loading} onClick={buildRecs}>Build Recommendations</button>
-      <h3>Recent Jobs</h3>
-      <ul>
-        {jobs.map(j => (
-          <li key={j.job + (j.ts || '')}>{j.job} @ {j.ts} - {j.ok ? 'OK' : 'Fail'}</li>
-        ))}
-      </ul>
+      <button disabled={loading || recRunning || recPending} onClick={buildRecs}>Build Recommendations</button>
+      {recPending && <span style={{ marginLeft: '0.5em' }}>In queue</span>}
 
       <h3>Watchlist</h3>
       <ul>

--- a/ui/src/pages/Runway.tsx
+++ b/ui/src/pages/Runway.tsx
@@ -1,124 +1,13 @@
 import React from "react";
 import { useEventStream } from "../useEventStream";
-import type { RunwayEvent } from "../useEventStream";
-
-interface EsiInfo {
-  remain: number | null;
-  reset: number | null;
-}
-
-function useRunwayVM(events: RunwayEvent[]) {
-  const inflight: Record<string, RunwayEvent> = {};
-  const builds: Record<string, RunwayEvent> = {};
-  let esi: EsiInfo = { remain: null, reset: null };
-  let queue: Record<string, number> = { P0: 0, P1: 0, P2: 0, P3: 0 };
-  const logs: RunwayEvent[] = [];
-
-  for (const e of events) {
-    if (e.type === "job_started" && e.runId) inflight[e.runId] = { ...e, progress: 0 };
-    if (e.type === "job_progress" && e.runId && inflight[e.runId]) {
-      inflight[e.runId].progress = e.progress ?? 0;
-      inflight[e.runId].detail = e.detail;
-    }
-    if (e.type === "job_log") logs.push(e);
-    if (e.type === "job_finished" && e.runId && inflight[e.runId])
-      inflight[e.runId] = { ...inflight[e.runId], ...e, done: true };
-    if (e.type === "build_started" && e.buildId)
-      builds[e.buildId] = { ...e, progress: 0 };
-    if (e.type === "build_progress" && e.buildId && builds[e.buildId]) {
-      builds[e.buildId].progress = e.progress ?? 0;
-      builds[e.buildId].stage = e.stage;
-      builds[e.buildId].detail = e.detail;
-    }
-    if (e.type === "build_finished" && e.buildId && builds[e.buildId])
-      builds[e.buildId] = { ...builds[e.buildId], ...e, done: true };
-    if (e.type === "esi") esi = { remain: e.remain ?? null, reset: e.reset ?? null };
-    if (e.type === "queue") queue = e.depth ?? queue;
-  }
-  const inflightList = Object.values(inflight).filter((x) => !x.done);
-  const recentJobs = Object.values(inflight)
-    .filter((x) => x.done)
-    .slice(-10)
-    .reverse();
-  const recentBuilds = Object.values(builds)
-    .filter((x) => x.done)
-    .slice(-5)
-    .reverse();
-  return { inflightList, recentJobs, recentBuilds, esi, queue, logs };
-}
+import RunwayPanel from "../RunwayPanel";
 
 export default function Runway() {
   const { connected, events } = useEventStream();
-  const { inflightList, recentJobs, recentBuilds, esi, queue, logs } =
-    useRunwayVM(events);
-  const dotStyle: React.CSSProperties = {
-    width: 10,
-    height: 10,
-    borderRadius: "50%",
-    backgroundColor: connected ? "green" : "red",
-    display: "inline-block",
-    marginRight: 8,
-  };
-  const trunc = (s: string) => (s && s.length > 80 ? s.slice(0, 80) + "…" : s);
-
   return (
     <div>
       <h2>Runway</h2>
-      <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-        <span style={dotStyle}></span>
-        <span>
-          ESI remain: {esi.remain ?? ""} reset: {esi.reset ?? ""}
-        </span>
-      </div>
-      <h3>Now Running</h3>
-      <ul>
-        {inflightList.length === 0 && <li>None</li>}
-        {inflightList.map((j) => (
-          <li key={j.runId} title={j.detail}>
-            <strong>{j.job}</strong> {j.progress}% {trunc(j.detail ?? "")}
-          </li>
-        ))}
-      </ul>
-      <h3>Queue</h3>
-      <div>
-        {Object.entries(queue).map(([k, v]) => (
-          <span
-            key={k}
-            style={{
-              marginRight: "8px",
-              padding: "2px 4px",
-              border: "1px solid #ccc",
-              borderRadius: "4px",
-            }}
-          >
-            {k}:{String(v)}
-          </span>
-        ))}
-      </div>
-      <h3>Recent Jobs</h3>
-      <ul>
-        {recentJobs.map((j) => (
-          <li key={j.runId} title={j.detail}>
-            <strong>{j.job}</strong> {j.ok ? "ok" : "fail"} {j.ms}ms {trunc(j.detail ?? "")}
-          </li>
-        ))}
-      </ul>
-      <h3>Recent Builds</h3>
-      <ul>
-        {recentBuilds.map((b) => (
-          <li key={b.buildId} title={b.detail}>
-            <strong>{b.job}</strong> {b.progress}% {b.stage} {trunc(b.detail ?? "")}
-          </li>
-        ))}
-      </ul>
-      <h3>Logs</h3>
-      <ul>
-        {logs.slice(-50).map((l, i) => (
-          <li key={i} title={l.message}>
-            {l.level}: {trunc(l.message ?? "")}
-          </li>
-        ))}
-      </ul>
+      <RunwayPanel connected={connected} events={events} />
     </div>
   );
 }

--- a/ui/src/runwayVM.ts
+++ b/ui/src/runwayVM.ts
@@ -1,0 +1,49 @@
+import type { RunwayEvent } from "./useEventStream";
+
+export interface PendingJob {
+  job: string;
+  runId: string;
+  queued_at: string;
+}
+
+export function useRunwayVM(events: RunwayEvent[]) {
+  const inflight: Record<string, RunwayEvent> = {};
+  const builds: Record<string, RunwayEvent> = {};
+  let esi = { remain: null as number | null, reset: null as number | null };
+  let queue: Record<string, number> = { P0: 0, P1: 0, P2: 0, P3: 0 };
+  let pending: PendingJob[] = [];
+  const logs: RunwayEvent[] = [];
+
+  for (const e of events) {
+    if (e.type === "job_started" && e.runId) inflight[e.runId] = { ...e, progress: 0 };
+    if (e.type === "job_progress" && e.runId && inflight[e.runId]) {
+      inflight[e.runId].progress = e.progress ?? 0;
+      inflight[e.runId].detail = e.detail;
+    }
+    if (e.type === "job_log") logs.push(e);
+    if (e.type === "job_finished" && e.runId && inflight[e.runId])
+      inflight[e.runId] = { ...inflight[e.runId], ...e, done: true };
+    if (e.type === "build_started" && e.buildId)
+      builds[e.buildId] = { ...e, progress: 0 };
+    if (e.type === "build_progress" && e.buildId && builds[e.buildId]) {
+      builds[e.buildId].progress = e.progress ?? 0;
+      builds[e.buildId].stage = e.stage;
+      builds[e.buildId].detail = e.detail;
+    }
+    if (e.type === "build_finished" && e.buildId && builds[e.buildId])
+      builds[e.buildId] = { ...builds[e.buildId], ...e, done: true };
+    if (e.type === "esi") esi = { remain: e.remain ?? null, reset: e.reset ?? null };
+    if (e.type === "queue") queue = e.depth ?? queue;
+    if (e.type === "jobs") pending = (e.pending as PendingJob[]) ?? pending;
+  }
+  const inflightList = Object.values(inflight).filter((x) => !x.done);
+  const recentJobs = Object.values(inflight)
+    .filter((x) => x.done)
+    .slice(-10)
+    .reverse();
+  const recentBuilds = Object.values(builds)
+    .filter((x) => x.done)
+    .slice(-5)
+    .reverse();
+  return { inflightList, recentJobs, recentBuilds, pending, esi, queue, logs };
+}


### PR DESCRIPTION
## Summary
- expose `/coverage` endpoint with snapshot counts and median age
- add shared RunwayPanel with pending queue display
- wire dashboard to event stream and disable build button while a run is active

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68afe5ecd6d483238c95993b2cddc6cf