### PR TITLE
Fix build by typing pending jobs and cleanup Runway page

### DIFF
--- a/ui/src/pages/Runway.tsx
+++ b/ui/src/pages/Runway.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useEventStream } from "../useEventStream";
 import RunwayPanel from "../RunwayPanel";
 

--- a/ui/src/runwayVM.ts
+++ b/ui/src/runwayVM.ts
@@ -1,10 +1,4 @@
-import type { RunwayEvent } from "./useEventStream";
-
-export interface PendingJob {
-  job: string;
-  runId: string;
-  queued_at: string;
-}
+import type { RunwayEvent, PendingJob } from "./useEventStream";
 
 export function useRunwayVM(events: RunwayEvent[]) {
   const inflight: Record<string, RunwayEvent> = {};

--- a/ui/src/useEventStream.ts
+++ b/ui/src/useEventStream.ts
@@ -2,6 +2,12 @@ import { useEffect, useRef, useState } from "react";
 import { getStatus } from "./api";
 import type { StatusSnapshot } from "./api";
 
+export interface PendingJob {
+  job: string;
+  runId: string;
+  queued_at: string;
+}
+
 export interface RunwayEvent {
   type: string;
   runId?: string;
@@ -20,6 +26,7 @@ export interface RunwayEvent {
   remain?: number;
   reset?: number;
   depth?: Record<string, number>;
+  pending?: PendingJob[];
   done?: boolean;
   polled?: boolean;
 }


### PR DESCRIPTION
## Summary
- export `PendingJob` type and add `pending` field to `RunwayEvent`
- update `useRunwayVM` to consume typed pending jobs
- remove unused React import from Runway page

## Testing
- `npm run lint`
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afec5be2588323855e72367f9751d0