### PR TITLE
Add DB tab and profit-first recommendations UI

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -8,6 +8,7 @@ import Portfolio from './pages/Portfolio';
 import Snipes from './pages/Snipes';
 import Runway from './pages/Runway';
 import Login from './pages/Login';
+import Db from './pages/Db';
 import { getAuthStatus } from './api';
 import './App.css';
 
@@ -23,6 +24,7 @@ export default function App() {
     <>
       <nav>
         <Link to="/">Dashboard</Link> |
+        <Link to="/db">DB</Link> |
         <Link to="/recommendations">Recommendations</Link> |
         <Link to="/portfolio">Portfolio</Link> |
         <Link to="/snipes">Snipes</Link> |
@@ -32,6 +34,7 @@ export default function App() {
       </nav>
       <Routes>
         <Route path="/" element={<Dashboard />} />
+        <Route path="/db" element={<Db />} />
         <Route path="/recommendations" element={<Recommendations />} />
         <Route path="/portfolio" element={<Portfolio />} />
         <Route path="/snipes" element={<Snipes />} />

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -77,10 +77,11 @@ export interface RecParams {
   sort?: string;
   dir?: string;
   search?: string;
-  min_net?: number;
+  min_profit_pct?: number;
   min_mom?: number;
   min_vol?: number;
-  all?: boolean;
+  show_all?: boolean;
+  mode?: string;
 }
 
 export async function getRecommendations(params: RecParams = {}) {
@@ -90,13 +91,55 @@ export async function getRecommendations(params: RecParams = {}) {
   if (params.sort) qs.set('sort', params.sort);
   if (params.dir) qs.set('dir', params.dir);
   if (params.search) qs.set('search', params.search);
-  if (params.min_net !== undefined) qs.set('min_net', String(params.min_net));
+  if (params.min_profit_pct !== undefined)
+    qs.set('min_profit_pct', String(params.min_profit_pct));
   if (params.min_mom !== undefined) qs.set('min_mom', String(params.min_mom));
   if (params.min_vol !== undefined) qs.set('min_vol', String(params.min_vol));
-  if (params.all) qs.set('all', 'true');
+  if (params.show_all) qs.set('show_all', 'true');
+  if (params.mode) qs.set('mode', params.mode);
   const res = await fetch(`${API_BASE}/recommendations?${qs.toString()}`);
   if (!res.ok) throw new Error('Failed to fetch recommendations');
   return res.json();
+}
+
+export interface DbParams {
+  limit?: number;
+  offset?: number;
+  sort?: string;
+  dir?: string;
+  search?: string;
+  deal?: string[];
+  min_profit_pct?: number;
+}
+
+export async function getDbItems(params: DbParams = {}) {
+  const qs = new URLSearchParams();
+  if (params.limit !== undefined) qs.set('limit', String(params.limit));
+  if (params.offset !== undefined) qs.set('offset', String(params.offset));
+  if (params.sort) qs.set('sort', params.sort);
+  if (params.dir) qs.set('dir', params.dir);
+  if (params.search) qs.set('search', params.search);
+  if (params.min_profit_pct !== undefined)
+    qs.set('min_profit_pct', String(params.min_profit_pct));
+  if (params.deal)
+    for (const d of params.deal) qs.append('deal', d);
+  const res = await fetch(`${API_BASE}/db/items?${qs.toString()}`);
+  if (!res.ok) throw new Error('Failed to fetch db items');
+  return res.json();
+}
+
+export interface DbItem {
+  type_id: number;
+  type_name: string;
+  best_bid: number | null;
+  best_ask: number | null;
+  last_updated: string;
+  fresh_ms: number;
+  profit_pct: number;
+  profit_isk: number;
+  deal: string;
+  mom?: number | null;
+  est_daily_vol?: number | null;
 }
 
 export async function getOpenOrders(limit = 100, search = '') {

--- a/ui/src/pages/Db.tsx
+++ b/ui/src/pages/Db.tsx
@@ -1,0 +1,245 @@
+import { useEffect, useState } from 'react';
+import { getDbItems, type DbItem } from '../api';
+import Spinner from '../Spinner';
+import ErrorBanner from '../ErrorBanner';
+import {
+  useReactTable,
+  type ColumnDef,
+  getCoreRowModel,
+  getSortedRowModel,
+  type SortingState,
+  flexRender,
+} from '@tanstack/react-table';
+import TypeName from '../TypeName';
+
+const columns: ColumnDef<DbItem>[] = [
+  {
+    accessorKey: 'type_name',
+    header: 'Item',
+    cell: ({ row }) => (
+      <TypeName id={row.original.type_id} name={row.original.type_name} />
+    ),
+  },
+  { accessorKey: 'best_bid', header: 'Best Bid', meta: { numeric: true } },
+  { accessorKey: 'best_ask', header: 'Best Ask', meta: { numeric: true } },
+  {
+    accessorKey: 'profit_pct',
+    header: 'Profit %',
+    meta: { numeric: true },
+    cell: (info) => (info.getValue<number>() * 100).toFixed(2),
+  },
+  {
+    accessorKey: 'profit_isk',
+    header: 'Profit ISK',
+    meta: { numeric: true },
+    cell: (info) =>
+      (info.getValue<number>() ?? 0).toLocaleString(undefined, {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      }),
+  },
+  { accessorKey: 'deal', header: 'Deal' },
+  {
+    accessorKey: 'mom',
+    header: 'MoM %',
+    meta: { numeric: true },
+    cell: (info) =>
+      info.getValue<number | null>() != null
+        ? (info.getValue<number>() * 100).toFixed(2)
+        : '',
+  },
+  {
+    accessorKey: 'est_daily_vol',
+    header: 'Daily Vol',
+    meta: { numeric: true },
+  },
+  {
+    accessorKey: 'fresh_ms',
+    header: 'Fresh',
+    cell: (info) => {
+      const age = info.getValue<number>() ?? 0;
+      const color = age < 120000 ? 'green' : age < 600000 ? 'yellow' : 'red';
+      return <span style={{ color }}>●</span>;
+    },
+  },
+  { accessorKey: 'last_updated', header: 'Updated' },
+];
+
+export default function Db() {
+  const [rows, setRows] = useState<DbItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(0);
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: 'last_updated', desc: true },
+  ]);
+  const [search, setSearch] = useState('');
+  const [minProfit, setMinProfit] = useState(0);
+  const [dealFilters, setDealFilters] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  async function refresh() {
+    setLoading(true);
+    try {
+      const sort = sorting[0]?.id ?? 'last_updated';
+      const dir = sorting[0]?.desc ? 'desc' : 'asc';
+      const data = await getDbItems({
+        limit: 50,
+        offset: page * 50,
+        sort,
+        dir,
+        search,
+        min_profit_pct: minProfit,
+        deal: dealFilters,
+      });
+      setRows(data.rows || []);
+      setTotal(data.total || 0);
+      setError('');
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page, sorting, search, minProfit, dealFilters]);
+
+  const table = useReactTable({
+    data: rows,
+    columns,
+    state: { sorting },
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    manualSorting: true,
+  });
+
+  function toggleDeal(d: string) {
+    setDealFilters((prev) =>
+      prev.includes(d) ? prev.filter((x) => x !== d) : [...prev, d]
+    );
+  }
+
+  function exportCsv() {
+    if (!rows.length) return;
+    const headers = [
+      'type_id',
+      'type_name',
+      'best_bid',
+      'best_ask',
+      'profit_pct',
+      'profit_isk',
+      'deal',
+      'last_updated',
+      'mom',
+      'est_daily_vol',
+    ];
+    const csvRows = rows.map((r) => [
+      r.type_id,
+      r.type_name,
+      r.best_bid ?? '',
+      r.best_ask ?? '',
+      r.profit_pct,
+      r.profit_isk,
+      r.deal,
+      r.last_updated,
+      r.mom ?? '',
+      r.est_daily_vol ?? '',
+    ]);
+    const csv = [headers.join(','), ...csvRows.map((r) => r.join(','))].join('\n');
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'db_items.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  return (
+    <div>
+      <h2>DB</h2>
+      <ErrorBanner message={error} />
+      {loading && <Spinner />}
+      <div>
+        <label>
+          Search:{' '}
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="name or id"
+          />
+        </label>
+        <label style={{ marginLeft: '1em' }}>
+          Min Profit %:{' '}
+          <input
+            type="number"
+            value={minProfit}
+            onChange={(e) => setMinProfit(Number(e.target.value))}
+          />
+        </label>
+        <span style={{ marginLeft: '1em' }}>
+          Deal:
+          {['Great', 'Good', 'Neutral', 'Bad'].map((d) => (
+            <label key={d} style={{ marginLeft: '0.5em' }}>
+              <input
+                type="checkbox"
+                checked={dealFilters.includes(d)}
+                onChange={() => toggleDeal(d)}
+              />{' '}
+              {d}
+            </label>
+          ))}
+        </span>
+        <button
+          style={{ marginLeft: '1em' }}
+          onClick={refresh}
+          disabled={loading}
+        >
+          Refresh
+        </button>
+        <button
+          style={{ marginLeft: '1em' }}
+          onClick={exportCsv}
+          disabled={!rows.length}
+        >
+          Export CSV
+        </button>
+      </div>
+      <table>
+        <thead>
+          {table.getHeaderGroups().map((hg) => (
+            <tr key={hg.id}>
+              {hg.headers.map((header) => (
+                <th
+                  key={header.id}
+                  onClick={header.column.getToggleSortingHandler?.()}
+                >
+                  {header.isPlaceholder
+                    ? null
+                    : (header.column.columnDef.header as string)}
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((row) => (
+            <tr key={row.original.type_id}>
+              {row.getVisibleCells().map((cell) => (
+                <td key={cell.id}>
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add dedicated DB tab listing all known items with profit, deal label, freshness, and pricing details
- update API utilities for profit-centric recommendation params and new DB items endpoint
- overhaul recommendations UI to profit-first, exposing profit metrics, deal ranks, freshness, and Show All toggle

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afec4072ac8323afb07e2eabcc3f4c