### PR TITLE
feat: add legacy mode to recommendation builder

### DIFF
--- a/app/service.py
+++ b/app/service.py
@@ -12,6 +12,7 @@ from .settings_service import (
     validate_settings,
 )
 from .recommender import build_recommendations
+from typing import Literal
 from .scheduler import run_tick
 from .db import connect, init_db
 from .valuation import compute_portfolio_snapshot, refresh_type_valuations
@@ -975,16 +976,24 @@ def recompute_valuations():
 
 
 @app.post("/recommendations/build")
-def recommendations_build(dry_run: bool = False, verbose: bool = False):
+def recommendations_build(
+    dry_run: bool = False,
+    verbose: bool = False,
+    mode: Literal["profit_only", "legacy"] = "profit_only",
+):
     """Trigger a recommendations build or return dry-run counts."""
-    res = build_recommendations(verbose=verbose, dry_run=dry_run)
+    res = build_recommendations(verbose=verbose, dry_run=dry_run, mode=mode)
     if dry_run:
         return res
     return {"rows": len(res)}
 
 
 @app.post("/jobs/{name}/run")
-def run_job(name: str, verbose: bool = False):
+def run_job(
+    name: str,
+    verbose: bool = False,
+    mode: Literal["profit_only", "legacy"] = "profit_only",
+):
     """Run a background job immediately.
 
     The optional ``verbose`` flag triggers additional event chatter so that
@@ -992,7 +1001,7 @@ def run_job(name: str, verbose: bool = False):
     """
 
     if name == "recommendations":
-        recs = build_recommendations(verbose=verbose)
+        recs = build_recommendations(verbose=verbose, mode=mode)
         return {"count": len(recs)}
     if name == "scheduler_tick":
         run_tick()

--- a/tests/test_recommendations_build_dry_run.py
+++ b/tests/test_recommendations_build_dry_run.py
@@ -62,6 +62,17 @@ def test_recommendations_build_dry_run(tmp_path, monkeypatch):
     assert data["scored"] == 3
     assert data["would_write"] == 3
 
+    # legacy mode should gate by freshness and MoM
+    resp = client.post("/recommendations/build", params={"dry_run": True, "mode": "legacy"})
+    assert resp.status_code == 200
+    legacy = resp.json()
+    assert legacy["candidates"] == 3
+    assert legacy["fresh_pass"] == 1
+    assert legacy["vol_pass"] == 1
+    assert legacy["mom_pass"] == 1
+    assert legacy["scored"] == 1
+    assert legacy["would_write"] == 1
+
     # ensure no rows written
     con = db.connect()
     try:


### PR DESCRIPTION
## Summary
- allow recommendations builder to toggle between profit-first and legacy gating
- pass mode through build and run job endpoints
- exercise legacy path in build dry-run tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aff5d856b483239fd931780e52b3d9