### PR TITLE
feat(ui): surface detailed job progress

### DIFF
--- a/ui/src/RunwayPanel.tsx
+++ b/ui/src/RunwayPanel.tsx
@@ -8,8 +8,16 @@ interface Props {
 }
 
 export default function RunwayPanel({ connected, events }: Props) {
-  const { inflightList, recentJobs, recentBuilds, pending, esi, queue, logs } =
-    useRunwayVM(events);
+  const {
+    inflightList,
+    buildInflight,
+    recentJobs,
+    recentBuilds,
+    pending,
+    esi,
+    queue,
+    logs,
+  } = useRunwayVM(events);
   const dotStyle: React.CSSProperties = {
     width: 10,
     height: 10,
@@ -30,10 +38,20 @@ export default function RunwayPanel({ connected, events }: Props) {
       </div>
       <h3>Now Running</h3>
       <ul>
-        {inflightList.length === 0 && <li>None</li>}
+        {inflightList.length === 0 && buildInflight.length === 0 && <li>None</li>}
         {inflightList.map((j) => (
           <li key={j.runId} title={j.detail}>
-            <strong>{j.job}</strong> {j.progress}% {trunc(j.detail ?? "")}
+            <strong>{j.job}</strong> {j.progress}%
+            {typeof j.done === "number" &&
+            typeof (j.total ?? j.meta?.total) === "number" ? (
+              <> {j.done}/{j.total ?? j.meta?.total}</>
+            ) : null}{" "}
+            {trunc(j.detail ?? "")}
+          </li>
+        ))}
+        {buildInflight.map((b) => (
+          <li key={b.buildId} title={b.detail}>
+            <strong>{b.job}</strong> {b.progress}% {b.stage} {trunc(b.detail ?? "")}
           </li>
         ))}
       </ul>

--- a/ui/src/runwayVM.ts
+++ b/ui/src/runwayVM.ts
@@ -9,14 +9,26 @@ export function useRunwayVM(events: RunwayEvent[]) {
   const logs: RunwayEvent[] = [];
 
   for (const e of events) {
-    if (e.type === "job_started" && e.runId) inflight[e.runId] = { ...e, progress: 0 };
+    if (e.type === "job_started" && e.runId)
+      inflight[e.runId] = { ...e, progress: 0 };
     if (e.type === "job_progress" && e.runId && inflight[e.runId]) {
       inflight[e.runId].progress = e.progress ?? 0;
       inflight[e.runId].detail = e.detail;
     }
+    if (e.job && e.phase && e.runId && inflight[e.runId]) {
+      if (e.phase === "start") {
+        inflight[e.runId] = { ...inflight[e.runId], ...e };
+      } else if (e.phase === "progress") {
+        inflight[e.runId].done = e.done;
+        inflight[e.runId].total = e.total;
+        inflight[e.runId].detail = e.detail;
+      } else if (e.phase === "finish") {
+        inflight[e.runId] = { ...inflight[e.runId], ...e, finished: true };
+      }
+    }
     if (e.type === "job_log") logs.push(e);
     if (e.type === "job_finished" && e.runId && inflight[e.runId])
-      inflight[e.runId] = { ...inflight[e.runId], ...e, done: true };
+      inflight[e.runId] = { ...inflight[e.runId], ...e, finished: true };
     if (e.type === "build_started" && e.buildId)
       builds[e.buildId] = { ...e, progress: 0 };
     if (e.type === "build_progress" && e.buildId && builds[e.buildId]) {
@@ -25,19 +37,29 @@ export function useRunwayVM(events: RunwayEvent[]) {
       builds[e.buildId].detail = e.detail;
     }
     if (e.type === "build_finished" && e.buildId && builds[e.buildId])
-      builds[e.buildId] = { ...builds[e.buildId], ...e, done: true };
+      builds[e.buildId] = { ...builds[e.buildId], ...e, finished: true };
     if (e.type === "esi") esi = { remain: e.remain ?? null, reset: e.reset ?? null };
     if (e.type === "queue") queue = e.depth ?? queue;
     if (e.type === "jobs") pending = (e.pending as PendingJob[]) ?? pending;
   }
-  const inflightList = Object.values(inflight).filter((x) => !x.done);
+  const inflightList = Object.values(inflight).filter((x) => !x.finished);
   const recentJobs = Object.values(inflight)
-    .filter((x) => x.done)
+    .filter((x) => x.finished)
     .slice(-10)
     .reverse();
+  const buildInflight = Object.values(builds).filter((b) => !b.finished);
   const recentBuilds = Object.values(builds)
-    .filter((x) => x.done)
+    .filter((x) => x.finished)
     .slice(-5)
     .reverse();
-  return { inflightList, recentJobs, recentBuilds, pending, esi, queue, logs };
+  return {
+    inflightList,
+    buildInflight,
+    recentJobs,
+    recentBuilds,
+    pending,
+    esi,
+    queue,
+    logs,
+  };
 }

--- a/ui/src/useEventStream.ts
+++ b/ui/src/useEventStream.ts
@@ -14,12 +14,24 @@ export interface RunwayEvent {
   buildId?: string;
   job?: string;
   progress?: number;
+  meta?: Record<string, unknown>;
+  phase?: string;
   detail?: string;
   level?: string;
   message?: string;
   stage?: string;
   ok?: boolean;
   itemsWritten?: number;
+  items_written?: number;
+  unique_types_touched?: number;
+  median_snapshot_age_ms?: number;
+  errors?: number;
+  tiers?: Record<string, number>;
+  selected?: number;
+  workers?: number;
+  expected_pages?: number;
+  done?: number;
+  total?: number;
   rows?: number;
   ms?: number;
   error?: string;
@@ -27,7 +39,7 @@ export interface RunwayEvent {
   reset?: number;
   depth?: Record<string, number>;
   pending?: PendingJob[];
-  done?: boolean;
+  finished?: boolean;
   polled?: boolean;
 }
 


### PR DESCRIPTION
## Summary
- expand RunwayEvent metadata to include scheduler/build progress counts
- show live scheduler/build progress and counts in Runway panel

## Testing
- `pytest`
- `npm --prefix ui run lint`
- `npm --prefix ui run build`


------
https://chatgpt.com/codex/tasks/task_e_68aff697666883238545434e98f33b49