### PR TITLE
feat: consolidate market tables

### DIFF
--- a/ui/src/DataTable.tsx
+++ b/ui/src/DataTable.tsx
@@ -1,0 +1,65 @@
+import { useReactTable, type ColumnDef, type SortingState, type OnChangeFn, getCoreRowModel, getSortedRowModel, flexRender } from '@tanstack/react-table';
+
+interface Props<T> {
+  columns: ColumnDef<T, unknown>[];
+  data: T[];
+  sorting: SortingState;
+  onSortingChange: OnChangeFn<SortingState>;
+  stickyHeader?: boolean;
+}
+
+export default function DataTable<T>({ columns, data, sorting, onSortingChange, stickyHeader = false }: Props<T>) {
+  const table = useReactTable({
+    data,
+    columns,
+    state: { sorting },
+    onSortingChange,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    manualSorting: true,
+  });
+
+  return (
+    <div>
+      <div style={{ marginBottom: '0.5em' }}>
+        {table
+          .getAllLeafColumns()
+          .filter((col) => col.getCanHide())
+          .map((col) => (
+            <label key={col.id} style={{ marginRight: '1em' }}>
+              <input
+                type="checkbox"
+                checked={col.getIsVisible()}
+                onChange={col.getToggleVisibilityHandler()}
+              />{' '}
+              {col.id}
+            </label>
+          ))}
+      </div>
+      <div style={{ overflowX: 'auto' }}>
+        <table>
+          <thead style={stickyHeader ? { position: 'sticky', top: 0, background: '#fff' } : undefined}>
+            {table.getHeaderGroups().map((hg) => (
+              <tr key={hg.id}>
+                {hg.headers.map((header) => (
+                  <th key={header.id} onClick={header.column.getToggleSortingHandler?.()}>
+                    {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table.getRowModel().rows.map((row) => (
+              <tr key={row.id}>
+                {row.getVisibleCells().map((cell) => (
+                  <td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/Db.tsx
+++ b/ui/src/pages/Db.tsx
@@ -2,15 +2,9 @@ import { useEffect, useState } from 'react';
 import { getDbItems, type DbItem } from '../api';
 import Spinner from '../Spinner';
 import ErrorBanner from '../ErrorBanner';
-import {
-  useReactTable,
-  type ColumnDef,
-  getCoreRowModel,
-  getSortedRowModel,
-  type SortingState,
-  flexRender,
-} from '@tanstack/react-table';
+import { type ColumnDef, type SortingState } from '@tanstack/react-table';
 import TypeName from '../TypeName';
+import DataTable from '../DataTable';
 
 const columns: ColumnDef<DbItem>[] = [
   {
@@ -104,16 +98,6 @@ export default function Db() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sorting, search, minProfit, dealFilters]);
 
-  const table = useReactTable({
-    data: rows,
-    columns,
-    state: { sorting },
-    onSortingChange: setSorting,
-    getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-    manualSorting: true,
-  });
-
   function toggleDeal(d: string) {
     setDealFilters((prev) =>
       prev.includes(d) ? prev.filter((x) => x !== d) : [...prev, d]
@@ -206,36 +190,24 @@ export default function Db() {
         >
           Export CSV
         </button>
+        {minProfit > 0 && (
+          <span
+            style={{ marginLeft: '0.5em', border: '1px solid #ccc', padding: '2px 4px' }}
+          >
+            Profit &gt; {minProfit}%
+            <button onClick={() => setMinProfit(0)} style={{ marginLeft: '0.5em' }}>
+              ×
+            </button>
+          </span>
+        )}
       </div>
-      <table>
-        <thead>
-          {table.getHeaderGroups().map((hg) => (
-            <tr key={hg.id}>
-              {hg.headers.map((header) => (
-                <th
-                  key={header.id}
-                  onClick={header.column.getToggleSortingHandler?.()}
-                >
-                  {header.isPlaceholder
-                    ? null
-                    : (header.column.columnDef.header as string)}
-                </th>
-              ))}
-            </tr>
-          ))}
-        </thead>
-        <tbody>
-          {table.getRowModel().rows.map((row) => (
-            <tr key={row.original.type_id}>
-              {row.getVisibleCells().map((cell) => (
-                <td key={cell.id}>
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <DataTable
+        columns={columns}
+        data={rows}
+        sorting={sorting}
+        onSortingChange={setSorting}
+        stickyHeader
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable DataTable with column toggles and sticky headers
- refactor DB and Recommendations pages to share DataTable
- include quick filter chips for profit and MoM thresholds

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aff7acc9d0832398a6d7159ed26389