### PR TITLE
Expose market side availability in listings

### DIFF
--- a/app/service.py
+++ b/app/service.py
@@ -278,6 +278,7 @@ def list_db_items(
     results = []
     deal_filter = {d.title() for d in (deal or [])}
     for tid, tname, bid, ask, ts, mom, vol in rows:
+        has_both = bid is not None and ask is not None
         profit_isk, profit_pct = compute_profit(bid, ask, fees, tick)
         if profit_pct < min_profit_pct:
             continue
@@ -299,6 +300,7 @@ def list_db_items(
                 "deal": label,
                 "mom": mom,
                 "est_daily_vol": vol,
+                "has_both_sides": has_both,
             }
         )
     allowed = {
@@ -395,6 +397,7 @@ def legacy_list_recommendations(
         daily_cap,
         rationale,
     ) in rows:
+        has_both = bid is not None and ask is not None
         profit_isk, profit_pct = compute_profit(bid, ask, fees, tick)
         if profit_pct < min_profit_pct:
             continue
@@ -428,6 +431,7 @@ def legacy_list_recommendations(
                 "uplift_mom": uplift_mom,
                 "daily_capacity": daily_cap,
                 "details": details,
+                "has_both_sides": has_both,
             }
         )
     allowed = {
@@ -535,6 +539,7 @@ def list_recommendations(
         daily_cap,
         rationale,
     ) in rows:
+        has_both = bid is not None and ask is not None
         profit_isk, profit_pct = compute_profit(bid, ask, fees, tick)
         if profit_pct < min_profit_pct:
             continue
@@ -566,6 +571,7 @@ def list_recommendations(
                 "uplift_mom": uplift_mom,
                 "daily_capacity": daily_cap,
                 "details": details,
+                "has_both_sides": has_both,
             }
         )
     allowed = {

--- a/tests/test_service_recommendations.py
+++ b/tests/test_service_recommendations.py
@@ -61,6 +61,7 @@ def test_db_items(tmp_path, monkeypatch):
     for row in data["rows"]:
         assert row["profit_pct"] >= 0
         assert "last_updated" in row
+        assert row["has_both_sides"] is True
 
 
 def test_recommendations_show_all(tmp_path, monkeypatch):
@@ -78,11 +79,13 @@ def test_recommendations_show_all(tmp_path, monkeypatch):
     data = resp.json()
     assert data["total"] == 1
     assert data["rows"][0]["type_id"] == 1
+    assert data["rows"][0]["has_both_sides"] is True
     resp = client.get("/recommendations", params={"show_all": True})
     assert resp.status_code == 200
     data = resp.json()
     assert data["total"] == 2
     assert {r["type_id"] for r in data["rows"]} == {1, 2}
+    assert all(r["has_both_sides"] for r in data["rows"])
 
 
 def seed_legacy(con):
@@ -133,3 +136,4 @@ def test_recommendations_legacy_mode(tmp_path, monkeypatch):
     data = resp.json()
     assert data["total"] == 1
     assert data["rows"][0]["type_id"] == 1
+    assert data["rows"][0]["has_both_sides"] is True

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -140,6 +140,7 @@ export interface DbItem {
   deal: string;
   mom?: number | null;
   est_daily_vol?: number | null;
+  has_both_sides: boolean;
 }
 
 export async function getOpenOrders(limit = 100, search = '') {

--- a/ui/src/pages/Db.tsx
+++ b/ui/src/pages/Db.tsx
@@ -20,7 +20,14 @@ const columns: ColumnDef<DbItem>[] = [
     accessorKey: 'profit_pct',
     header: 'Profit %',
     meta: { numeric: true },
-    cell: (info) => (info.getValue<number>() * 100).toFixed(2),
+    cell: ({ row, getValue }) => {
+      const val = (getValue<number>() * 100).toFixed(2) + '%';
+      return (
+        <span style={{ color: row.original.has_both_sides ? undefined : 'gray' }}>
+          {val}
+        </span>
+      );
+    },
   },
   {
     accessorKey: 'profit_isk',

--- a/ui/src/pages/Recommendations.tsx
+++ b/ui/src/pages/Recommendations.tsx
@@ -31,6 +31,7 @@ interface Rec {
   uplift_mom: number | null;
   daily_capacity: number | null;
   details: Record<string, unknown>;
+  has_both_sides: boolean;
 }
 
 export default function Recommendations() {
@@ -126,7 +127,14 @@ export default function Recommendations() {
       accessorKey: 'profit_pct',
       header: 'Profit %',
       meta: { numeric: true },
-      cell: (info) => (info.getValue<number>() * 100).toFixed(2),
+      cell: ({ row, getValue }) => {
+        const val = (getValue<number>() * 100).toFixed(2) + '%';
+        return (
+          <span style={{ color: row.original.has_both_sides ? undefined : 'gray' }}>
+            {val}
+          </span>
+        );
+      },
     },
     {
       accessorKey: 'profit_isk',


### PR DESCRIPTION
## Summary
- include `has_both_sides` on `/db/items` and `/recommendations`
- gray out profit percent when market data is incomplete
- update tests for new field

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0a52bda7883239aee9c50f724fbd2