### PR TITLE
Unify listing logic and lock profit-only recommendations

### DIFF
--- a/ui/src/RunwayPanel.tsx
+++ b/ui/src/RunwayPanel.tsx
@@ -47,6 +47,19 @@ export default function RunwayPanel({ connected, events }: Props) {
               <> {j.done}/{j.total ?? j.meta?.total}</>
             ) : null}{" "}
             {trunc(j.detail ?? "")}
+            {j.workers != null || j.selected != null || j.tiers ? (
+              <>
+                {j.workers != null && <> · workers:{j.workers}</>}
+                {j.selected != null && <> · selected:{j.selected}</>}
+                {j.tiers && (
+                  <> · tiers:{
+                    Object.entries(j.tiers).map(
+                      ([k, v]) => `${k}:${v}`
+                    ).join(',')
+                  }</>
+                )}
+              </>
+            ) : null}
           </li>
         ))}
         {buildInflight.map((b) => (
@@ -84,7 +97,12 @@ export default function RunwayPanel({ connected, events }: Props) {
       <ul>
         {recentJobs.map((j) => (
           <li key={j.runId} title={j.detail}>
-            <strong>{j.job}</strong> {j.ok ? "ok" : "fail"} {j.ms}ms {trunc(j.detail ?? "")}
+            <strong>{j.job}</strong> {j.ok ? "ok" : "fail"} {j.ms}ms
+            {typeof j.items_written === 'number' && <> · wrote {j.items_written}</>}
+            {typeof j.median_snapshot_age_ms === 'number' && (
+              <> · age {j.median_snapshot_age_ms}ms</>
+            )}{' '}
+            {trunc(j.detail ?? '')}
           </li>
         ))}
       </ul>

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -81,7 +81,6 @@ export interface RecParams {
   min_mom?: number;
   min_vol?: number;
   show_all?: boolean;
-  mode?: string;
 }
 
 export async function getRecommendations(params: RecParams = {}) {
@@ -96,7 +95,7 @@ export async function getRecommendations(params: RecParams = {}) {
   if (params.min_mom !== undefined) qs.set('min_mom', String(params.min_mom));
   if (params.min_vol !== undefined) qs.set('min_vol', String(params.min_vol));
   if (params.show_all) qs.set('show_all', 'true');
-  if (params.mode) qs.set('mode', params.mode);
+  qs.set('mode', 'profit_only');
   const res = await fetch(`${API_BASE}/recommendations?${qs.toString()}`);
   if (!res.ok) throw new Error('Failed to fetch recommendations');
   return res.json();

--- a/ui/src/pages/Recommendations.tsx
+++ b/ui/src/pages/Recommendations.tsx
@@ -64,7 +64,6 @@ export default function Recommendations() {
         min_profit_pct: minProfit,
         min_mom: minMom,
         show_all: showAll,
-        mode: 'profit_only',
       };
       const data = await getRecommendations(params);
       setRows(data.rows || []);
@@ -222,6 +221,9 @@ export default function Recommendations() {
   return (
     <div>
       <h2>Recommendations</h2>
+      <p>
+        Mode: Profit-only · Min Profit: {minProfit}% · Show All: {showAll ? 'On' : 'Off'}
+      </p>
       <ErrorBanner message={error} />
       {loading && <Spinner />}
       <div>


### PR DESCRIPTION
## Summary
- centralize latest price listing into `_list_latest_items` used by both DB and recommendations endpoints
- force profit-first recommendations client and show active filters
- expose worker/tiers progress and write stats in Runway panel

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`
- `cd ui && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0a699e3c48323a982f0b50fc328f8