### PR TITLE
Display active fees in market tables

### DIFF
--- a/ui/src/pages/Db.tsx
+++ b/ui/src/pages/Db.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { getDbItems, type DbItem } from '../api';
+import { getDbItems, type DbItem, getSettings } from '../api';
 import Spinner from '../Spinner';
 import ErrorBanner from '../ErrorBanner';
 import { type ColumnDef, type SortingState } from '@tanstack/react-table';
@@ -76,6 +76,7 @@ export default function Db() {
   const [dealFilters, setDealFilters] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const [fees, setFees] = useState<{ buy: number; sell: number } | null>(null);
 
   async function refresh() {
     setLoading(true);
@@ -104,6 +105,20 @@ export default function Db() {
     refresh();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sorting, search, minProfit, dealFilters]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const s = await getSettings();
+        setFees({
+          buy: s.BROKER_BUY,
+          sell: s.SALES_TAX + s.BROKER_SELL + s.RELIST_HAIRCUT,
+        });
+      } catch {
+        // ignore
+      }
+    })();
+  }, []);
 
   function toggleDeal(d: string) {
     setDealFilters((prev) =>
@@ -197,6 +212,13 @@ export default function Db() {
         >
           Export CSV
         </button>
+        {fees && (
+          <span
+            style={{ marginLeft: '0.5em', border: '1px solid #ccc', padding: '2px 4px' }}
+          >
+            Fees: buy {(fees.buy * 100).toFixed(2)}% sell {(fees.sell * 100).toFixed(2)}%
+          </span>
+        )}
         {minProfit > 0 && (
           <span
             style={{ marginLeft: '0.5em', border: '1px solid #ccc', padding: '2px 4px' }}

--- a/ui/src/pages/Recommendations.tsx
+++ b/ui/src/pages/Recommendations.tsx
@@ -4,6 +4,7 @@ import {
   getWatchlist,
   addWatchlist,
   removeWatchlist,
+  getSettings,
   type RecParams,
 } from '../api';
 import Spinner from '../Spinner';
@@ -49,6 +50,7 @@ export default function Recommendations() {
   const [selected, setSelected] = useState<Rec | null>(null);
   const [watchlist, setWatchlist] = useState<Set<number>>(new Set());
   const [showAll, setShowAll] = useState(false);
+  const [fees, setFees] = useState<{ buy: number; sell: number } | null>(null);
 
   async function refresh() {
     setLoading(true);
@@ -84,6 +86,20 @@ export default function Recommendations() {
     refresh();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [page, sorting, search, showAll, minProfit, minMom]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const s = await getSettings();
+        setFees({
+          buy: s.BROKER_BUY,
+          sell: s.SALES_TAX + s.BROKER_SELL + s.RELIST_HAIRCUT,
+        });
+      } catch {
+        // ignore
+      }
+    })();
+  }, []);
 
   const toggleWatchlist = useCallback(async (id: number) => {
     try {
@@ -223,6 +239,13 @@ export default function Recommendations() {
       <h2>Recommendations</h2>
       <p>
         Mode: Profit-only · Min Profit: {minProfit}% · Show All: {showAll ? 'On' : 'Off'}
+        {fees && (
+          <span
+            style={{ marginLeft: '0.5em', border: '1px solid #ccc', padding: '2px 4px' }}
+          >
+            Fees: buy {(fees.buy * 100).toFixed(2)}% sell {(fees.sell * 100).toFixed(2)}%
+          </span>
+        )}
       </p>
       <ErrorBanner message={error} />
       {loading && <Spinner />}


### PR DESCRIPTION
## Summary
- show buy/sell fee percentages above Recommendations and DB tables
- pull fee values from settings API once and render as a chip

## Testing
- `npm run lint`
- `pytest tests/test_service_recommendations.py`

------
https://chatgpt.com/codex/tasks/task_e_68b0b37f075883238ee292b6a39a80db