### PR TITLE
Refactor time handling and fee logic

### DIFF
--- a/app/char_sync.py
+++ b/app/char_sync.py
@@ -1,8 +1,8 @@
-from datetime import datetime
 import logging
 from .esi import BASE, get, paged
 from .db import connect
 from .config import DATASOURCE
+from .util import utcnow
 
 logger = logging.getLogger(__name__)
 
@@ -14,7 +14,7 @@ def sync_wallet_balance(con, char_id, token):
     if code == 304:
         logger.info("Wallet balance not modified")
         return
-    ts = datetime.utcnow().isoformat()
+    ts = utcnow()
     con.execute(
         "INSERT OR REPLACE INTO wallet_snapshots (ts_utc, balance) VALUES (?, ?)",
         (ts, float(data)),
@@ -118,7 +118,7 @@ def sync_open_orders(con, char_id, token):
                 o.get("range"),
                 o.get("min_volume"),
                 o.get("escrow", 0.0),
-                datetime.utcnow().isoformat(),
+                utcnow(),
             ),
         )
     con.commit()
@@ -159,7 +159,7 @@ def sync_order_history(con, char_id, token, page_limit=10):
                     o.get("range"),
                     o.get("min_volume"),
                     o.get("escrow", 0.0),
-                    datetime.utcnow().isoformat(),
+                    utcnow(),
                     o.get("state", "finished"),
                 ),
             )
@@ -189,7 +189,7 @@ def sync_assets(con, char_id, token):
                 row["location_id"],
                 row.get("location_type"),
                 row.get("location_flag"),
-                datetime.utcnow().isoformat(),
+                utcnow(),
             ),
         )
         count += 1

--- a/app/jita_snapshots.py
+++ b/app/jita_snapshots.py
@@ -1,9 +1,11 @@
 import time
 from datetime import datetime
 import requests
+import time
 from .db import connect
 from .config import REGION_ID, DATASOURCE, STATION_ID
 from .esi import BASE
+from .util import utcnow
 
 
 def respect_error_limit(r):
@@ -46,7 +48,7 @@ def fetch_orders_for_type(tid, order_type):
 def refresh_one(con, tid):
     bid, bid_c, bid_u = fetch_orders_for_type(tid, "buy")
     ask, ask_c, ask_u = fetch_orders_for_type(tid, "sell")
-    ts = datetime.utcnow().isoformat()
+    ts = utcnow()
     con.execute(
         """
         INSERT OR REPLACE INTO market_snapshots

--- a/app/jobs.py
+++ b/app/jobs.py
@@ -10,7 +10,6 @@ headers exposed via :mod:`app.esi`.
 """
 
 from dataclasses import dataclass, field
-from datetime import datetime
 import heapq
 import json
 import time
@@ -19,6 +18,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 from . import db, esi
 from .status import STATUS
 from .emit import job_started, job_finished, queue_event, jobs_event, run_id
+from .util import utcnow
 
 # Public state for status reporting -------------------------------------------------
 
@@ -41,9 +41,7 @@ class Job:
     args: tuple = ()
     kwargs: dict = field(default_factory=dict)
     priority: str = "P2"
-    queued_at: str = field(
-        default_factory=lambda: datetime.utcnow().isoformat() + "Z"
-    )
+    queued_at: str = field(default_factory=utcnow)
     run_id: str = field(default_factory=run_id)
 
 
@@ -152,7 +150,7 @@ def worker(limiter: RateLimiter) -> None:
 def record_job(name: str, ok: bool, details: Optional[Any] = None) -> None:
     """Record a job execution in the ``jobs_history`` table."""
 
-    ts = datetime.utcnow().isoformat()
+    ts = utcnow()
     con = db.connect()
     try:
         con.execute(

--- a/app/market.py
+++ b/app/market.py
@@ -12,6 +12,7 @@ from .config import (
     MIN_DAYS_TRADED,
     VENUE,
 )
+from .pricing import compute_profit, Fees
 
 
 def station_region_id(station_id):
@@ -50,9 +51,23 @@ def region_history(type_id, region_id):
 
 
 def margin_after_fees(buy_px, sell_px):
-    return sell_px * (1 - SALES_TAX - BROKER_SELL - RELIST_HAIRCUT) - buy_px * (
-        1 + BROKER_BUY
+    """Return net profit between ``buy_px`` and ``sell_px`` after fees.
+
+    This leverages :func:`app.pricing.compute_profit` to avoid duplicating
+    fee logic. ``buy_px`` represents the price paid while ``sell_px`` is the
+    price received.
+    """
+    fees = Fees(
+        buy_total=BROKER_BUY,
+        sell_total=SALES_TAX + BROKER_SELL + RELIST_HAIRCUT,
     )
+    profit, _ = compute_profit(
+        best_bid=sell_px,
+        best_ask=buy_px,
+        fees=fees,
+        tick=lambda v, _: v,
+    )
+    return profit
 
 
 def mom_uplift(df):

--- a/app/pnl.py
+++ b/app/pnl.py
@@ -1,6 +1,8 @@
 from collections import deque, defaultdict
 from datetime import datetime
+from datetime import datetime, timezone
 from .db import connect
+from .util import utcnow
 
 
 def load_transactions(con):
@@ -130,7 +132,7 @@ def pnl_fifo():
                 INSERT INTO inventory_cost_basis(type_id, remaining_qty, avg_cost, updated)
                 VALUES (?,?,?,?)
                 """,
-                (type_id, total_qty, avg_cost, datetime.utcnow().isoformat()),
+                (type_id, total_qty, avg_cost, utcnow()),
             )
     con.commit()
     con.close()

--- a/app/status.py
+++ b/app/status.py
@@ -1,6 +1,6 @@
-from datetime import datetime
 from typing import Any, Dict
 from fastapi import APIRouter
+from .util import utcnow
 
 status_router = APIRouter()
 
@@ -27,7 +27,7 @@ def update_status(evt: Dict[str, Any]) -> None:
                 "runId": evt.get("runId"),
                 "progress": 0,
                 "detail": "",
-                "since": datetime.utcnow().isoformat() + "Z",
+                "since": utcnow(),
             }
         )
     elif t == "job_progress":
@@ -54,7 +54,7 @@ def update_status(evt: Dict[str, Any]) -> None:
         rec: Dict[str, Any] = {
             "job": job_name,
             "ok": evt.get("ok"),
-            "ts": datetime.utcnow().isoformat() + "Z",
+            "ts": utcnow(),
         }
         if evt.get("ms") is not None:
             rec["ms"] = evt.get("ms")

--- a/app/trends.py
+++ b/app/trends.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from .db import connect
 from .config import REGION_ID, DATASOURCE
 from .esi import BASE
+from .util import utcnow
 import requests
 
 
@@ -33,7 +34,7 @@ def refresh_trends(limit_types=300):
         "SELECT type_id FROM region_types WHERE region_id=? LIMIT ?",
         (REGION_ID, limit_types),
     ).fetchall()
-    now = datetime.utcnow().isoformat()
+    now = utcnow()
     for (tid,) in rows:
         hist = region_history(tid)
         mom = compute_mom(hist)

--- a/app/types_sync.py
+++ b/app/types_sync.py
@@ -1,13 +1,13 @@
 import sqlite3
-from datetime import datetime
 from .esi import BASE, paged
 from .config import REGION_ID, DATASOURCE
 from .db import connect
+from .util import utcnow
 
 
 def seed_region_types():
     con = connect()
-    now = datetime.utcnow().isoformat()
+    now = utcnow()
     url = f"{BASE}/markets/{REGION_ID}/types/"
     for tid in paged(url, params={"datasource": DATASOURCE}):
         con.execute(

--- a/app/util.py
+++ b/app/util.py
@@ -1,0 +1,14 @@
+from datetime import datetime, timezone
+
+
+def utcnow() -> str:
+    """Return current UTC time formatted for SQLite (``YYYY-MM-DD HH:MM:SS``)."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def parse_utc(ts: str) -> datetime:
+    """Parse a timestamp into a UTC-aware ``datetime``."""
+    dt = datetime.fromisoformat(ts)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt

--- a/app/valuation.py
+++ b/app/valuation.py
@@ -1,7 +1,9 @@
 from datetime import datetime
+from datetime import datetime, timezone
 from .db import connect
 from .config import STATION_ID, REGION_ID, SALES_TAX, BROKER_SELL
 from .market import best_bid_ask_station
+from .util import utcnow
 
 
 def refresh_type_valuations(con, type_ids):
@@ -12,7 +14,7 @@ def refresh_type_valuations(con, type_ids):
             INSERT OR REPLACE INTO type_valuations (type_id, quicksell_bid, mark_ask, updated)
             VALUES (?,?,?,?)
             """,
-            (tid, bid or 0.0, ask or 0.0, datetime.utcnow().isoformat()),
+            (tid, bid or 0.0, ask or 0.0, utcnow()),
         )
     con.commit()
 
@@ -59,7 +61,7 @@ def compute_portfolio_snapshot(con):
     nav_quicksell = balance + buy_escrow + qs_val + sell_net
     nav_mark = balance + buy_escrow + mk_val + sell_net
 
-    day = datetime.utcnow().date().isoformat()
+    day = datetime.now(timezone.utc).date().isoformat()
     con.execute(
         """
         INSERT OR REPLACE INTO portfolio_daily

--- a/app/ws_bus.py
+++ b/app/ws_bus.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, WebSocket
 import asyncio
 import json
-from datetime import datetime
+from .util import utcnow
 
 router = APIRouter()
 _clients: set[WebSocket] = set()
@@ -47,7 +47,7 @@ _heartbeat_task: asyncio.Task | None = None
 
 async def _heartbeat_loop() -> None:
     while True:
-        await broadcast({"type": "heartbeat", "now": datetime.utcnow().isoformat() + "Z"})
+        await broadcast({"type": "heartbeat", "now": utcnow()})
         await asyncio.sleep(5)
 
 

--- a/tests/test_recommendations_build_dry_run.py
+++ b/tests/test_recommendations_build_dry_run.py
@@ -1,5 +1,5 @@
 from fastapi.testclient import TestClient
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import sys
 
@@ -25,7 +25,7 @@ def test_recommendations_build_dry_run(tmp_path, monkeypatch):
                 (3, 180, 0.05),
             ],
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         recent = (now - timedelta(minutes=5)).strftime("%Y-%m-%d %H:%M:%S")
         old = (now - timedelta(hours=1)).strftime("%Y-%m-%d %H:%M:%S")
         con.execute(

--- a/tests/test_scheduler_tick_events.py
+++ b/tests/test_scheduler_tick_events.py
@@ -3,12 +3,13 @@ import pathlib, sys
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
+from datetime import datetime, timezone
 from app import db, scheduler
 from app.config import STATION_ID
 
 
 def _fake_refresh_one(con, tid):
-    ts = datetime.utcnow().isoformat()
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
     con.execute(
         """
         INSERT OR REPLACE INTO market_snapshots

--- a/tests/test_service_coverage.py
+++ b/tests/test_service_coverage.py
@@ -1,5 +1,5 @@
 from fastapi.testclient import TestClient
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import sys
 from pathlib import Path
 
@@ -15,10 +15,9 @@ def test_coverage_endpoint(tmp_path, monkeypatch):
     db.init_db()
     con = db.connect()
     try:
-        now = datetime.utcnow()
-        fmt = "%Y-%m-%d %H:%M:%S"
-        recent = (now - timedelta(minutes=5)).strftime(fmt)
-        old = (now - timedelta(minutes=20)).strftime(fmt)
+        now = datetime.now(timezone.utc)
+        recent = (now - timedelta(minutes=5)).strftime("%Y-%m-%d %H:%M:%S")
+        old = (now - timedelta(minutes=20)).strftime("%Y-%m-%d %H:%M:%S")
         con.execute(
             "INSERT INTO market_snapshots(ts_utc, type_id, station_id, best_bid, best_ask, bid_count, ask_count, jita_bid_units, jita_ask_units) VALUES (?,?,?,?,?,?,?,?,?)",
             (recent, 1, STATION_ID, 10, 12, 0, 0, 0, 0),

--- a/tests/test_service_inventory_coverage.py
+++ b/tests/test_service_inventory_coverage.py
@@ -1,5 +1,5 @@
 from fastapi.testclient import TestClient
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import sys
 from pathlib import Path
 
@@ -15,10 +15,9 @@ def test_inventory_coverage(tmp_path, monkeypatch):
     db.init_db()
     con = db.connect()
     try:
-        now = datetime.utcnow()
-        fmt = "%Y-%m-%d %H:%M:%S"
-        recent = (now - timedelta(minutes=5)).strftime(fmt)
-        old = (now - timedelta(minutes=20)).strftime(fmt)
+        now = datetime.now(timezone.utc)
+        recent = (now - timedelta(minutes=5)).strftime("%Y-%m-%d %H:%M:%S")
+        old = (now - timedelta(minutes=20)).strftime("%Y-%m-%d %H:%M:%S")
         con.execute(
             "INSERT INTO market_snapshots(ts_utc, type_id, station_id, best_bid, best_ask, bid_count, ask_count, jita_bid_units, jita_ask_units) VALUES (?,?,?,?,?,?,?,?,?)",
             (recent, 1, STATION_ID, 10, 12, 0, 0, 0, 0),

--- a/tests/test_service_recommendations.py
+++ b/tests/test_service_recommendations.py
@@ -7,7 +7,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from fastapi.testclient import TestClient
 from app import service, db, type_cache
 import app.config as config
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 
 def seed_basic(con):
@@ -21,8 +21,8 @@ def seed_basic(con):
         """
         INSERT INTO market_snapshots(ts_utc, type_id, station_id, best_bid, best_ask, bid_count, ask_count, jita_bid_units, jita_ask_units)
         VALUES
-        ('2024-01-01T00:00:00',1,?,110,100,0,0,0,0),
-        ('2024-01-01T00:00:00',2,?,220,200,0,0,0,0)
+        ('2024-01-01 00:00:00',1,?,110,100,0,0,0,0),
+        ('2024-01-01 00:00:00',2,?,220,200,0,0,0,0)
         """,
         (config.STATION_ID, config.STATION_ID),
     )
@@ -35,7 +35,7 @@ def seed_basic(con):
     con.execute(
         """
         INSERT INTO recommendations(type_id, station_id, ts_utc)
-        VALUES (1, ?, '2024-01-01T00:00:00')
+        VALUES (1, ?, '2024-01-01 00:00:00')
         """,
         (config.STATION_ID,),
     )
@@ -89,7 +89,7 @@ def test_recommendations_show_all(tmp_path, monkeypatch):
 
 
 def seed_legacy(con):
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     stale = now - timedelta(hours=1)
     con.execute(
         """
@@ -104,7 +104,7 @@ def seed_legacy(con):
         (?,1,?,110,100,0,0,0,0),
         (?,2,?,220,200,0,0,0,0)
         """,
-        (now.isoformat(), config.STATION_ID, stale.isoformat(), config.STATION_ID),
+        (now.strftime("%Y-%m-%d %H:%M:%S"), config.STATION_ID, stale.strftime("%Y-%m-%d %H:%M:%S"), config.STATION_ID),
     )
     con.execute(
         """


### PR DESCRIPTION
## Summary
- centralize UTC time formatting and parsing utilities
- eliminate duplicated fee math using pricing.compute_profit
- replace deprecated datetime.utcnow usages across services and tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1dceacdd08323865470afb68f3ba5