### PR TITLE
Streamline event dispatch

### DIFF
--- a/app/emit.py
+++ b/app/emit.py
@@ -3,7 +3,6 @@ import time
 from uuid import uuid4
 from typing import Optional
 from .ws_bus import broadcast
-from . import status
 
 
 def run_id() -> str:
@@ -11,7 +10,6 @@ def run_id() -> str:
 
 
 async def _send(evt: dict) -> None:
-    status.update_status(evt)
     await broadcast(evt)
 
 


### PR DESCRIPTION
## Summary
- push status updates through the websocket broadcast helper to eliminate duplication
- harden websocket endpoint by handling disconnects and logging unexpected errors
- simplify emit helper now that broadcast manages status

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1e44f38d883239b2f66081d507102