### PR TITLE
refactor: centralize UTC datetime helper

### DIFF
--- a/app/pnl.py
+++ b/app/pnl.py
@@ -1,6 +1,5 @@
 from collections import deque, defaultdict
 from datetime import datetime
-from datetime import datetime, timezone
 from .db import connect
 from .util import utcnow
 

--- a/app/service.py
+++ b/app/service.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
-from datetime import datetime, timezone
 from contextlib import asynccontextmanager
 from typing import Any, Literal
 from statistics import median
@@ -26,7 +25,7 @@ from .ticks import tick
 from .pricing import compute_profit, deal_label, Fees
 from .status import status_router
 from .ws_bus import router as ws_router, start_heartbeat, stop_heartbeat
-from .util import utcnow, parse_utc
+from .util import utcnow, utcnow_dt, parse_utc
 import json
 
 
@@ -299,7 +298,7 @@ def _list_latest_items(
         ).fetchall()
     finally:
         con.close()
-    now = datetime.now(timezone.utc)
+    now = utcnow_dt()
     results = []
     for row in rows:
         if include_rec:
@@ -464,7 +463,7 @@ def legacy_list_recommendations(
         ).fetchall()
     finally:
         con.close()
-    now = datetime.now(timezone.utc)
+    now = utcnow_dt()
     results = []
     for (
         tid,
@@ -837,7 +836,7 @@ def inventory_coverage():
     finally:
         con.close()
 
-    now = datetime.now(timezone.utc)
+    now = utcnow_dt()
     ages: list[int] = []
     oldest_type: int | None = None
     oldest_age = -1
@@ -888,7 +887,7 @@ def coverage_summary():
     finally:
         con.close()
 
-    now = datetime.now(timezone.utc)
+    now = utcnow_dt()
     ages = [
         int((now - parse_utc(ts)).total_seconds() * 1000)
         for (ts,) in rows

--- a/app/util.py
+++ b/app/util.py
@@ -6,6 +6,11 @@ def utcnow() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
 
 
+def utcnow_dt() -> datetime:
+    """Return the current timezone-aware UTC ``datetime``."""
+    return datetime.now(timezone.utc)
+
+
 def parse_utc(ts: str) -> datetime:
     """Parse a timestamp into a UTC-aware ``datetime``."""
     dt = datetime.fromisoformat(ts)

--- a/app/valuation.py
+++ b/app/valuation.py
@@ -1,9 +1,7 @@
-from datetime import datetime
-from datetime import datetime, timezone
 from .db import connect
 from .config import STATION_ID, REGION_ID, SALES_TAX, BROKER_SELL
 from .market import best_bid_ask_station
-from .util import utcnow
+from .util import utcnow, utcnow_dt
 
 
 def refresh_type_valuations(con, type_ids):
@@ -61,7 +59,7 @@ def compute_portfolio_snapshot(con):
     nav_quicksell = balance + buy_escrow + qs_val + sell_net
     nav_mark = balance + buy_escrow + mk_val + sell_net
 
-    day = datetime.now(timezone.utc).date().isoformat()
+    day = utcnow_dt().date().isoformat()
     con.execute(
         """
         INSERT OR REPLACE INTO portfolio_daily

--- a/tests/test_recommendations_build_dry_run.py
+++ b/tests/test_recommendations_build_dry_run.py
@@ -1,5 +1,5 @@
 from fastapi.testclient import TestClient
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from pathlib import Path
 import sys
 
@@ -8,6 +8,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from app import service, db, config
 from app import recommender
+from app.util import utcnow_dt
 
 
 def test_recommendations_build_dry_run(tmp_path, monkeypatch):
@@ -25,7 +26,7 @@ def test_recommendations_build_dry_run(tmp_path, monkeypatch):
                 (3, 180, 0.05),
             ],
         )
-        now = datetime.now(timezone.utc)
+        now = utcnow_dt()
         recent = (now - timedelta(minutes=5)).strftime("%Y-%m-%d %H:%M:%S")
         old = (now - timedelta(hours=1)).strftime("%Y-%m-%d %H:%M:%S")
         con.execute(

--- a/tests/test_scheduler_tick_events.py
+++ b/tests/test_scheduler_tick_events.py
@@ -1,15 +1,14 @@
-from datetime import datetime
 import pathlib, sys
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
-from datetime import datetime, timezone
 from app import db, scheduler
 from app.config import STATION_ID
+from app.util import utcnow
 
 
 def _fake_refresh_one(con, tid):
-    ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    ts = utcnow()
     con.execute(
         """
         INSERT OR REPLACE INTO market_snapshots

--- a/tests/test_service_coverage.py
+++ b/tests/test_service_coverage.py
@@ -1,5 +1,5 @@
 from fastapi.testclient import TestClient
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 import sys
 from pathlib import Path
 
@@ -8,6 +8,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from app import service, db
 from app.config import STATION_ID
+from app.util import utcnow_dt
 
 
 def test_coverage_endpoint(tmp_path, monkeypatch):
@@ -15,7 +16,7 @@ def test_coverage_endpoint(tmp_path, monkeypatch):
     db.init_db()
     con = db.connect()
     try:
-        now = datetime.now(timezone.utc)
+        now = utcnow_dt()
         recent = (now - timedelta(minutes=5)).strftime("%Y-%m-%d %H:%M:%S")
         old = (now - timedelta(minutes=20)).strftime("%Y-%m-%d %H:%M:%S")
         con.execute(

--- a/tests/test_service_inventory_coverage.py
+++ b/tests/test_service_inventory_coverage.py
@@ -1,5 +1,5 @@
 from fastapi.testclient import TestClient
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 import sys
 from pathlib import Path
 
@@ -8,6 +8,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from app import service, db
 from app.config import STATION_ID
+from app.util import utcnow_dt
 
 
 def test_inventory_coverage(tmp_path, monkeypatch):
@@ -15,7 +16,7 @@ def test_inventory_coverage(tmp_path, monkeypatch):
     db.init_db()
     con = db.connect()
     try:
-        now = datetime.now(timezone.utc)
+        now = utcnow_dt()
         recent = (now - timedelta(minutes=5)).strftime("%Y-%m-%d %H:%M:%S")
         old = (now - timedelta(minutes=20)).strftime("%Y-%m-%d %H:%M:%S")
         con.execute(

--- a/tests/test_service_recommendations.py
+++ b/tests/test_service_recommendations.py
@@ -7,7 +7,8 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from fastapi.testclient import TestClient
 from app import service, db, type_cache
 import app.config as config
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
+from app.util import utcnow_dt
 
 
 def seed_basic(con):
@@ -89,7 +90,7 @@ def test_recommendations_show_all(tmp_path, monkeypatch):
 
 
 def seed_legacy(con):
-    now = datetime.now(timezone.utc)
+    now = utcnow_dt()
     stale = now - timedelta(hours=1)
     con.execute(
         """


### PR DESCRIPTION
## Summary
- add `utcnow_dt` to util module for timezone-aware datetimes
- replace scattered `datetime.now(timezone.utc)` usage with `utcnow_dt`
- update tests to use `utcnow`/`utcnow_dt`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `cd ui && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1f8177e40832391fd4cf3891440b7