### PR TITLE
refactor: centralize db connections with session context manager

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -1,5 +1,6 @@
 import sqlite3
 import pathlib
+from contextlib import contextmanager
 
 DB_PATH = pathlib.Path("eve_trader.sqlite3")
 
@@ -231,3 +232,17 @@ def init_db():
     con.executescript(DDL)
     con.commit()
     return con
+
+
+@contextmanager
+def session():
+    """Context manager yielding a SQLite connection.
+
+    Ensures the connection is closed after use to avoid repeated
+    ``try/finally`` blocks throughout the codebase.
+    """
+    con = connect()
+    try:
+        yield con
+    finally:
+        con.close()


### PR DESCRIPTION
## Summary
- add reusable `session` context manager for SQLite connections
- update service endpoints to use the new context manager and remove manual connection handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1fd44e31083239d40786a506f11c5