### PR TITLE
refactor: centralize fee calculations

### DIFF
--- a/app/market.py
+++ b/app/market.py
@@ -5,14 +5,9 @@ from .config import (
     STATION_ID,
     REGION_ID,
     DATASOURCE,
-    SALES_TAX,
-    BROKER_SELL,
-    BROKER_BUY,
-    RELIST_HAIRCUT,
     MIN_DAYS_TRADED,
-    VENUE,
 )
-from .pricing import compute_profit, Fees
+from .pricing import compute_profit, default_fees
 
 
 def station_region_id(station_id):
@@ -57,10 +52,7 @@ def margin_after_fees(buy_px, sell_px):
     fee logic. ``buy_px`` represents the price paid while ``sell_px`` is the
     price received.
     """
-    fees = Fees(
-        buy_total=BROKER_BUY,
-        sell_total=SALES_TAX + BROKER_SELL + RELIST_HAIRCUT,
-    )
+    fees = default_fees()
     profit, _ = compute_profit(
         best_bid=sell_px,
         best_ask=buy_px,

--- a/app/pricing.py
+++ b/app/pricing.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Callable, Tuple, Optional, Dict
+from typing import Callable, Tuple, Optional, Dict, Mapping
 from .ticks import tick as default_tick
 
 @dataclass
@@ -8,6 +8,30 @@ class Fees:
     """Aggregate trading fees for buy and sell sides."""
     buy_total: float
     sell_total: float
+
+
+def default_fees() -> Fees:
+    """Return :class:`Fees` constructed from static config constants.
+
+    Centralizes knowledge of trading fee parameters to avoid repeating
+    ``config`` imports and manual arithmetic across modules.
+    """
+    from .config import BROKER_BUY, SALES_TAX, BROKER_SELL, RELIST_HAIRCUT
+
+    return Fees(
+        buy_total=BROKER_BUY,
+        sell_total=SALES_TAX + BROKER_SELL + RELIST_HAIRCUT,
+    )
+
+
+def fees_from_settings(settings: Mapping[str, float]) -> Fees:
+    """Build a :class:`Fees` instance from a settings mapping."""
+    return Fees(
+        buy_total=settings["BROKER_BUY"],
+        sell_total=settings["SALES_TAX"]
+        + settings["BROKER_SELL"]
+        + settings["RELIST_HAIRCUT"],
+    )
 
 
 def compute_profit(

--- a/app/service.py
+++ b/app/service.py
@@ -22,7 +22,7 @@ from .snipes import find_snipes
 from .config import SNIPE_EPSILON, SNIPE_Z, SPREAD_BUFFER, STATION_ID, REC_FRESH_MS
 from .market import margin_after_fees
 from .ticks import tick
-from .pricing import compute_profit, deal_label, Fees
+from .pricing import compute_profit, deal_label, fees_from_settings
 from .status import status_router
 from .ws_bus import router as ws_router, start_heartbeat, stop_heartbeat
 from .util import utcnow, utcnow_dt, parse_utc
@@ -233,12 +233,7 @@ def _list_latest_items(
 ) -> dict[str, Any]:
     """Shared listing logic for latest price snapshots."""
     settings = get_settings()
-    fees = Fees(
-        buy_total=settings["BROKER_BUY"],
-        sell_total=settings["SALES_TAX"]
-        + settings["BROKER_SELL"]
-        + settings["RELIST_HAIRCUT"],
-    )
+    fees = fees_from_settings(settings)
     thresholds = settings["DEAL_THRESHOLDS"]
     with session() as con:
         where = ["lp.station_id = ?"]
@@ -394,12 +389,7 @@ def legacy_list_recommendations(
 ):
     """Return recommendations using legacy gating on freshness, MoM, and volume."""
     settings = get_settings()
-    fees = Fees(
-        buy_total=settings["BROKER_BUY"],
-        sell_total=settings["SALES_TAX"]
-        + settings["BROKER_SELL"]
-        + settings["RELIST_HAIRCUT"],
-    )
+    fees = fees_from_settings(settings)
     thresholds = settings["DEAL_THRESHOLDS"]
     if min_mom == 0.0:
         min_mom = settings["MOM_THRESHOLD"]

--- a/tests/test_pricing_fees.py
+++ b/tests/test_pricing_fees.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+# Ensure 'app' package is importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app import config
+from app.pricing import default_fees, fees_from_settings
+
+
+def test_default_fees_matches_config():
+    fees = default_fees()
+    assert fees.buy_total == config.BROKER_BUY
+    assert fees.sell_total == config.SALES_TAX + config.BROKER_SELL + config.RELIST_HAIRCUT
+
+
+def test_fees_from_settings_overrides():
+    settings = {
+        "BROKER_BUY": 0.01,
+        "SALES_TAX": 0.02,
+        "BROKER_SELL": 0.03,
+        "RELIST_HAIRCUT": 0.04,
+    }
+    fees = fees_from_settings(settings)
+    assert fees.buy_total == settings["BROKER_BUY"]
+    assert fees.sell_total == settings["SALES_TAX"] + settings["BROKER_SELL"] + settings["RELIST_HAIRCUT"]


### PR DESCRIPTION
## Summary
- add `default_fees` and `fees_from_settings` helpers to avoid duplicating trade fee math
- use new helpers in market snapshot and listing endpoints
- cover fee helpers with unit tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1fed1b1a08323a43853460df44323