### PR TITLE
Improve websocket client pruning and logging

### DIFF
--- a/tests/test_ws_bus_disconnect.py
+++ b/tests/test_ws_bus_disconnect.py
@@ -33,4 +33,5 @@ def test_broadcast_prunes_dead_clients(caplog):
     assert bad not in ws_bus._clients
     assert good.sent[0] == json.dumps({"type": "test"})
     assert any("WebSocket send failed" in r.message for r in caplog.records)
+    assert any("WebSocket pruned" in r.message for r in caplog.records)
     ws_bus._clients.clear()


### PR DESCRIPTION
## Summary
- handle send failures in broadcast helper by trying to close sockets and pruning them
- log pruned websocket clients for better observability
- test that broadcast logs send failures and pruning

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b2084834cc8323b1883cc66bd3d8c4