### PR TITLE
Improve WebSocket failure logging

### DIFF
--- a/tests/test_ws_bus_disconnect.py
+++ b/tests/test_ws_bus_disconnect.py
@@ -12,12 +12,16 @@ from app import ws_bus
 class GoodWS:
     def __init__(self):
         self.sent = []
+        self.client = "good"
 
     async def send_text(self, txt: str) -> None:
         self.sent.append(txt)
 
 
 class BadWS:
+    def __init__(self):
+        self.client = "bad"
+
     async def send_text(self, txt: str) -> None:
         raise RuntimeError("boom")
 
@@ -32,6 +36,6 @@ def test_broadcast_prunes_dead_clients(caplog):
     assert good in ws_bus._clients
     assert bad not in ws_bus._clients
     assert good.sent[0] == json.dumps({"type": "test"})
-    assert any("WebSocket send failed" in r.message for r in caplog.records)
+    assert any("WebSocket send failed for bad" in r.message for r in caplog.records)
     assert any("WebSocket pruned" in r.message for r in caplog.records)
     ws_bus._clients.clear()


### PR DESCRIPTION
## Summary
- log client when WebSocket broadcast fails and prune cleanly
- treat cancelled WebSocket connections as normal disconnects
- test that dead clients are pruned with new log format

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b209605bc08323a16e66d3acd89cb8