### PR TITLE
Handle non-JSON data in websocket broadcast

### DIFF
--- a/app/ws_bus.py
+++ b/app/ws_bus.py
@@ -20,7 +20,12 @@ async def broadcast(evt: dict) -> None:
     if len(_history) > HISTORY_MAX:
         _history.pop(0)
 
-    msg = json.dumps(evt)
+    # ``evt`` may occasionally contain objects like ``datetime`` which are not
+    # JSON serialisable by default. ``default=str`` provides a best-effort
+    # coercion to string ensuring that the broadcast never raises because of
+    # such values. This keeps the websocket pipeline resilient to unexpected
+    # payloads while still logging them for debugging.
+    msg = json.dumps(evt, default=str)
     dead: list[WebSocket] = []
     for ws in list(_clients):
         try:

--- a/tests/test_ws_bus_serialization.py
+++ b/tests/test_ws_bus_serialization.py
@@ -1,0 +1,32 @@
+import asyncio
+import json
+from datetime import datetime, timezone
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from app import ws_bus
+
+
+class GoodWS:
+    def __init__(self):
+        self.sent = []
+        self.client = "good"
+
+    async def send_text(self, txt: str) -> None:
+        self.sent.append(txt)
+
+
+def test_broadcast_serializes_datetimes():
+    good = GoodWS()
+    ws_bus._clients.clear()
+    ws_bus._clients.add(good)
+    ws_bus._history.clear()
+
+    evt = {"type": "test", "when": datetime(2024, 1, 1, tzinfo=timezone.utc)}
+    asyncio.run(ws_bus.broadcast(evt))
+
+    assert json.loads(good.sent[0])["when"] == str(evt["when"])
+    ws_bus._clients.clear()
+    ws_bus._history.clear()


### PR DESCRIPTION
## Summary
- allow broadcast helper to serialize datetime and other objects by using `json.dumps(..., default=str)`
- cover websocket broadcast with a regression test for datetime payloads

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b20a63e73c832380ccf3483ff8590f