### PR TITLE
Log broadcast errors in websocket emit helper

### DIFF
--- a/app/emit.py
+++ b/app/emit.py
@@ -1,7 +1,9 @@
 import asyncio
+import logging
 import time
 from uuid import uuid4
 from typing import Optional
+
 from .ws_bus import broadcast
 
 
@@ -10,7 +12,10 @@ def run_id() -> str:
 
 
 async def _send(evt: dict) -> None:
-    await broadcast(evt)
+    try:
+        await broadcast(evt)
+    except Exception:
+        logging.exception("broadcast failed: %s", evt)
 
 
 def emit_sync(evt: dict) -> None:

--- a/tests/test_emit_error_logging.py
+++ b/tests/test_emit_error_logging.py
@@ -1,0 +1,19 @@
+import logging
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from app import emit
+
+
+def test_emit_sync_logs_broadcast_errors(monkeypatch, caplog):
+    def boom(evt):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(emit, "broadcast", boom)
+
+    with caplog.at_level(logging.ERROR):
+        emit.emit_sync({"type": "x"})
+
+    assert any("broadcast failed" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- log and swallow failures when broadcasting websocket events
- test that `emit_sync` logs errors from broadcast

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b211e787a483238075e164da01ae04