### PR TITLE
Use pricing fees in portfolio valuation

### DIFF
--- a/app/valuation.py
+++ b/app/valuation.py
@@ -1,6 +1,7 @@
-from .db import connect
-from .config import STATION_ID, REGION_ID, SALES_TAX, BROKER_SELL
+from .config import STATION_ID, REGION_ID
 from .market import best_bid_ask_station
+from .pricing import fees_from_settings
+from .settings_service import get_settings
 from .util import utcnow, utcnow_dt
 
 
@@ -54,7 +55,8 @@ def compute_portfolio_snapshot(con):
         qs_val += (bid or 0.0) * qty
         mk_val += (ask or bid or 0.0) * qty
 
-    sell_net = sell_gross * (1 - SALES_TAX - BROKER_SELL)
+    fees = fees_from_settings(get_settings())
+    sell_net = sell_gross * (1 - fees.sell_total)
 
     nav_quicksell = balance + buy_escrow + qs_val + sell_net
     nav_mark = balance + buy_escrow + mk_val + sell_net

--- a/tests/test_service_portfolio_nav.py
+++ b/tests/test_service_portfolio_nav.py
@@ -6,7 +6,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from app import service, db
-from app import config
+from app.pricing import default_fees
 
 
 def _seed_portfolio(con):
@@ -63,7 +63,8 @@ def test_portfolio_nav_snapshot(tmp_path, monkeypatch):
     data = resp.json()
 
     # Expected calculations
-    sell_net = 20 * (1 - config.SALES_TAX - config.BROKER_SELL)
+    fees = default_fees()
+    sell_net = 20 * (1 - fees.sell_total)
     assert data["wallet_balance"] == 100.0
     assert data["buy_escrow"] == 5.0
     assert data["sell_gross"] == 20.0

--- a/tests/test_service_portfolio_summary.py
+++ b/tests/test_service_portfolio_summary.py
@@ -4,7 +4,8 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from app import service, db, config
+from app import service, db
+from app.pricing import default_fees
 
 
 def _seed_portfolio(con):
@@ -68,7 +69,8 @@ def test_portfolio_summary(tmp_path, monkeypatch):
     resp = client.get("/portfolio/summary", params={"basis": "mark"})
     assert resp.status_code == 200
     data = resp.json()
-    sell_net = 20 * (1 - config.SALES_TAX - config.BROKER_SELL)
+    fees = default_fees()
+    sell_net = 20 * (1 - fees.sell_total)
     sell_value_qs = 16.0 + sell_net
     sell_value_mk = 24.0 + sell_net
     assert data["liquid"] == 100.0


### PR DESCRIPTION
## Summary
- derive portfolio sell-side fees via settings and pricing module
- adjust portfolio tests to compute expected net using pricing default fees

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`
- `cd ui && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2128e8bd883239bca30540641ca80