### PR TITLE
feat(events): emit pipeline update events

### DIFF
--- a/app/emit.py
+++ b/app/emit.py
@@ -119,6 +119,19 @@ def jobs_event(pending: list[dict]) -> None:
     emit_sync({"type": "jobs", "pending": pending})
 
 
+# Pipeline update helpers ------------------------------------------------------------
+
+
+def pipeline_price_updated(count: int, as_of: str) -> None:
+    """Emit an event signalling fresh market price data."""
+    emit_sync({"type": "pipeline.price.updated", "count": count, "as_of": as_of})
+
+
+def pipeline_profit_updated(count: int, as_of: str) -> None:
+    """Emit an event signalling refreshed profit/valuation data."""
+    emit_sync({"type": "pipeline.profit.updated", "count": count, "as_of": as_of})
+
+
 def build_finished(buildId: str, ok: bool, rows: int = 0, ms: int = 0, error: str | None = None) -> None:
     emit_sync(
         {

--- a/app/recommender.py
+++ b/app/recommender.py
@@ -9,7 +9,13 @@ from .config import (
     MOM_THRESHOLD,
 )
 from .jobs import record_job
-from .emit import build_started, build_progress, build_finished
+from .emit import (
+    build_started,
+    build_progress,
+    build_finished,
+    pipeline_profit_updated,
+)
+from .util import utcnow
 from typing import Literal
 
 
@@ -146,6 +152,7 @@ def build_recommendations(
         con.commit()
         record_job("recommendations", True, {"count": scored})
         build_finished(bid, True, rows=scored, ms=ms)
+        pipeline_profit_updated(scored, utcnow())
         return results
     except Exception as e:
         ms = int((time.time() - t0) * 1000)

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -6,7 +6,14 @@ from .db import connect
 from .jita_snapshots import refresh_one
 from .jobs import record_job
 from .status import STATUS
-from .emit import job_started, job_progress, job_finished, emit_sync
+from .emit import (
+    job_started,
+    job_progress,
+    job_finished,
+    emit_sync,
+    pipeline_price_updated,
+)
+from .util import utcnow
 
 logger = logging.getLogger(__name__)
 
@@ -197,3 +204,4 @@ def run_tick(max_calls: int = 800, workers: int = 6) -> None:
             }
         )
         job_finished(rid, ok=True, items=count, ms=ms)
+        pipeline_price_updated(completed, utcnow())

--- a/app/service.py
+++ b/app/service.py
@@ -26,6 +26,7 @@ from .pricing import compute_profit, deal_label, fees_from_settings
 from .status import status_router
 from .ws_bus import router as ws_router, start_heartbeat, stop_heartbeat
 from .util import utcnow, utcnow_dt, parse_utc
+from .emit import pipeline_profit_updated
 import json
 
 
@@ -908,6 +909,7 @@ def recompute_valuations():
         if ids:
             refresh_type_valuations(con, sorted(ids))
         count = len(ids)
+    pipeline_profit_updated(count, utcnow())
     return {"count": count}
 
 

--- a/tests/test_scheduler_tick_events.py
+++ b/tests/test_scheduler_tick_events.py
@@ -65,3 +65,8 @@ def test_scheduler_tick_emits_structured_events(tmp_path, monkeypatch):
     assert finish["unique_types_touched"] == 3
     assert finish["errors"] == 0
 
+    # price pipeline event emitted with count and timestamp
+    price_evt = next(e for e in events if e.get("type") == "pipeline.price.updated")
+    assert price_evt["count"] == 3
+    assert "as_of" in price_evt
+


### PR DESCRIPTION
## Summary
- add pipeline price/profit update event helpers
- broadcast price update after scheduler tick
- broadcast profit update after recommendations build and valuation recompute

## Testing
- `pytest`
- `cd ui && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b216d6a48c8323af08b16152de5b9e