### PR TITLE
feat(ui): add unified staleness badge

### DIFF
--- a/ui/src/StalenessBadge.tsx
+++ b/ui/src/StalenessBadge.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function StalenessBadge({ ms }: { ms: number }) {
+  let label = 'Stale';
+  let color: string = 'red';
+  if (ms < 5 * 60 * 1000) {
+    label = 'Fresh';
+    color = 'green';
+  } else if (ms < 30 * 60 * 1000) {
+    label = 'Warm';
+    color = 'orange';
+  }
+  return <span style={{ color }}>{label}</span>;
+}

--- a/ui/src/pages/Db.tsx
+++ b/ui/src/pages/Db.tsx
@@ -4,6 +4,7 @@ import Spinner from '../Spinner';
 import ErrorBanner from '../ErrorBanner';
 import { type ColumnDef, type SortingState } from '@tanstack/react-table';
 import TypeName from '../TypeName';
+import StalenessBadge from '../StalenessBadge';
 import DataTable from '../DataTable';
 
 const columns: ColumnDef<DbItem>[] = [
@@ -56,12 +57,8 @@ const columns: ColumnDef<DbItem>[] = [
   },
   {
     accessorKey: 'fresh_ms',
-    header: 'Fresh',
-    cell: (info) => {
-      const age = info.getValue<number>() ?? 0;
-      const color = age < 120000 ? 'green' : age < 600000 ? 'yellow' : 'red';
-      return <span style={{ color }}>●</span>;
-    },
+    header: 'Staleness',
+    cell: (info) => <StalenessBadge ms={info.getValue<number>() ?? 0} />,
   },
   { accessorKey: 'last_updated', header: 'Updated' },
 ];

--- a/ui/src/pages/Recommendations.tsx
+++ b/ui/src/pages/Recommendations.tsx
@@ -10,6 +10,7 @@ import {
 import Spinner from '../Spinner';
 import ErrorBanner from '../ErrorBanner';
 import TypeName from '../TypeName';
+import StalenessBadge from '../StalenessBadge';
 import {
   type ColumnDef,
   type SortingState,
@@ -180,12 +181,8 @@ export default function Recommendations() {
     },
     {
       accessorKey: 'fresh_ms',
-      header: 'Fresh',
-      cell: (info) => {
-        const age = info.getValue<number>() ?? 0;
-        const color = age < 120000 ? 'green' : age < 600000 ? 'yellow' : 'red';
-        return <span style={{ color }}>●</span>;
-      },
+      header: 'Staleness',
+      cell: (info) => <StalenessBadge ms={info.getValue<number>() ?? 0} />,
     },
     { accessorKey: 'last_updated', header: 'Updated' },
     {


### PR DESCRIPTION
## Summary
- add reusable StalenessBadge component
- show staleness consistently on DB and recommendation tables

## Testing
- `npm --prefix ui run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b21830f1408323b53e6197319b3351