### PR TITLE
Fix UI build errors by cleaning imports and scheduler update

### DIFF
--- a/ui/src/StalenessBadge.tsx
+++ b/ui/src/StalenessBadge.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 export default function StalenessBadge({ ms }: { ms: number }) {
   let label = 'Stale';
   let color: string = 'red';

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -74,7 +74,8 @@ export default function Dashboard() {
   async function toggleScheduler(name: string, enabled: boolean) {
     setLoading(true);
     try {
-      await updateSchedulers({ [name]: { enabled } });
+      const cfg = schedulers[name];
+      await updateSchedulers({ [name]: { enabled, interval: cfg.interval } });
       await refresh();
     } catch (e: unknown) {
       if (e instanceof Error) {


### PR DESCRIPTION
## Summary
- Remove unused React import from `StalenessBadge` to fix TypeScript build warning
- Provide scheduler interval when toggling enable/disable to satisfy `updateSchedulers` type

## Testing
- `npm run build`
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b219e5730483239821787309b100f6