### PR TITLE
feat: expose scheduler runtime stats on dashboard

### DIFF
--- a/tests/test_service_schedulers.py
+++ b/tests/test_service_schedulers.py
@@ -17,7 +17,12 @@ def test_schedulers_get_put(tmp_path, monkeypatch):
     resp = client.get("/schedulers")
     assert resp.status_code == 200
     data = resp.json()
-    assert data["sync_character"]["enabled"] is True
+    sc = data["sync_character"]
+    assert sc["enabled"] is True
+    assert "last_run_at" in sc
+    assert "next_run_at" in sc
+    assert "running" in sc
+    assert "queued" in sc
 
     # Update one job
     payload = {"sync_character": {"enabled": False, "interval": 120}}

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -17,6 +17,11 @@ import TypeName from '../TypeName';
 interface SchedulerCfg {
   enabled: boolean;
   interval: number;
+  concurrency?: number;
+  running?: boolean;
+  queued?: number;
+  last_run_at?: string | null;
+  next_run_at?: string | null;
 }
 
 export default function Dashboard() {
@@ -137,7 +142,12 @@ export default function Dashboard() {
           <tr>
             <th>Job</th>
             <th>Interval (m)</th>
+            <th>Concurrency</th>
             <th>Enabled</th>
+            <th>Running</th>
+            <th>Queued</th>
+            <th>Last Run</th>
+            <th>Next Run</th>
             <th>Actions</th>
           </tr>
         </thead>
@@ -146,7 +156,12 @@ export default function Dashboard() {
             <tr key={name}>
               <td>{name}</td>
               <td>{cfg.interval}</td>
+              <td>{cfg.concurrency ?? ''}</td>
               <td>{cfg.enabled ? 'Yes' : 'No'}</td>
+              <td>{cfg.running ? 'Yes' : 'No'}</td>
+              <td>{cfg.queued ?? 0}</td>
+              <td>{cfg.last_run_at ?? ''}</td>
+              <td>{cfg.next_run_at ?? ''}</td>
               <td>
                 <button disabled={loading} onClick={() => runNow(name)}>Run now</button>{' '}
                 <button


### PR DESCRIPTION
## Summary
- extend /schedulers endpoint with last/next run, running, queue and concurrency stats
- display new scheduler runtime information on dashboard table
- cover scheduler endpoint runtime fields with test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b21d3d89b883238b6acd174430a421