### PR TITLE
Handle scheduler tasks via run_job

### DIFF
--- a/app/service.py
+++ b/app/service.py
@@ -14,6 +14,8 @@ from .settings_service import (
 )
 from .recommender import build_recommendations
 from .scheduler import run_tick
+from .trends import refresh_trends
+from .run_character_sync import main as sync_character_main
 from .db import session, init_db
 from .valuation import compute_portfolio_snapshot, refresh_type_valuations
 from .auth import get_token, token_status
@@ -960,10 +962,18 @@ def run_job(
     testers can observe progress updates even in fast unit-test scenarios.
     """
 
-    if name == "recommendations":
+    if name in {"recommendations", "recommender_scan"}:
         recs = build_recommendations(verbose=verbose, mode=mode)
         return {"count": len(recs)}
-    if name == "scheduler_tick":
+    if name in {"scheduler_tick", "snapshot_orders"}:
         run_tick()
+        return {"status": "ok"}
+    if name == "refresh_trends":
+        refresh_trends()
+        return {"status": "ok"}
+    if name == "refresh_type_valuations":
+        return recompute_valuations()
+    if name == "sync_character":
+        sync_character_main()
         return {"status": "ok"}
     raise HTTPException(status_code=404, detail="Job not found")

--- a/tests/test_run_jobs.py
+++ b/tests/test_run_jobs.py
@@ -1,0 +1,28 @@
+from fastapi.testclient import TestClient
+import sys
+from pathlib import Path
+
+# Ensure 'app' package is importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app import service, db  # noqa: E402
+
+
+def test_run_jobs_known(monkeypatch, tmp_path):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "test.sqlite3")
+    db.init_db()
+    client = TestClient(service.app)
+
+    # stub heavy job functions
+    monkeypatch.setattr(service, "run_tick", lambda: None)
+    monkeypatch.setattr(service, "refresh_trends", lambda: None)
+    monkeypatch.setattr(service, "sync_character_main", lambda: None)
+    monkeypatch.setattr(service, "recompute_valuations", lambda: {"count": 0})
+    monkeypatch.setattr(service, "build_recommendations", lambda **kw: [])
+
+    assert client.post("/jobs/snapshot_orders/run").status_code == 200
+    assert client.post("/jobs/refresh_trends/run").status_code == 200
+    assert client.post("/jobs/refresh_type_valuations/run").status_code == 200
+    assert client.post("/jobs/sync_character/run").status_code == 200
+    assert client.post("/jobs/recommender_scan/run").status_code == 200
+    assert client.post("/jobs/unknown/run").status_code == 404


### PR DESCRIPTION
## Summary
- allow `/jobs/{name}/run` to trigger scheduler tasks like snapshot refresh, trend updates, character sync, valuations, and recommendations
- cover new run_job routes with unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b21e30ebbc83239e0483dc482bbef7