### PR TITLE
Add server-side pagination for DB items

### DIFF
--- a/ui/src/DataTable.tsx
+++ b/ui/src/DataTable.tsx
@@ -1,22 +1,46 @@
-import { useReactTable, type ColumnDef, type SortingState, type OnChangeFn, getCoreRowModel, getSortedRowModel, flexRender } from '@tanstack/react-table';
+import {
+  useReactTable,
+  type ColumnDef,
+  type SortingState,
+  type OnChangeFn,
+  type PaginationState,
+  getCoreRowModel,
+  getSortedRowModel,
+  flexRender,
+} from '@tanstack/react-table';
 
 interface Props<T> {
   columns: ColumnDef<T, unknown>[];
   data: T[];
   sorting: SortingState;
   onSortingChange: OnChangeFn<SortingState>;
+  pageIndex: number;
+  pageCount: number;
+  onPageChange: OnChangeFn<PaginationState>;
   stickyHeader?: boolean;
 }
 
-export default function DataTable<T>({ columns, data, sorting, onSortingChange, stickyHeader = false }: Props<T>) {
+export default function DataTable<T>({
+  columns,
+  data,
+  sorting,
+  onSortingChange,
+  pageIndex,
+  pageCount,
+  onPageChange,
+  stickyHeader = false,
+}: Props<T>) {
   const table = useReactTable({
     data,
     columns,
-    state: { sorting },
+    state: { sorting, pagination: { pageIndex, pageSize: 25 } },
     onSortingChange,
+    onPaginationChange: onPageChange,
+    pageCount,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     manualSorting: true,
+    manualPagination: true,
   });
 
   return (
@@ -59,6 +83,25 @@ export default function DataTable<T>({ columns, data, sorting, onSortingChange, 
             ))}
           </tbody>
         </table>
+      </div>
+      <div style={{ marginTop: '0.5em' }}>
+        <button
+          onClick={() => table.previousPage()}
+          disabled={!table.getCanPreviousPage()}
+          style={{ marginRight: '0.5em' }}
+        >
+          Previous
+        </button>
+        <span>
+          Page {pageIndex + 1} of {pageCount || 1}
+        </span>
+        <button
+          onClick={() => table.nextPage()}
+          disabled={!table.getCanNextPage()}
+          style={{ marginLeft: '0.5em' }}
+        >
+          Next
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- paginate database item table with 25-row pages and navigation controls
- fetch paged data with stable sorting and filtering from the backend
- compute profit metrics in SQL and apply limit/offset to reduce DB load

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b22ba563808323886e31d3d740d0a1