### PR TITLE
Allow negative profit display on DB items

### DIFF
--- a/app/market.py
+++ b/app/market.py
@@ -58,6 +58,7 @@ def margin_after_fees(buy_px, sell_px):
         best_ask=buy_px,
         fees=fees,
         tick=lambda v, _: v,
+        floor_negative=False,
     )
     return profit
 

--- a/app/service.py
+++ b/app/service.py
@@ -255,6 +255,7 @@ def _list_latest_items(
     meta: int | None = None,
     show_all: bool = False,
     include_rec: bool = False,
+    allow_negative: bool = False,
     default_sort: str = "last_updated",
 ) -> dict[str, Any]:
     """Shared listing logic for latest price snapshots."""
@@ -265,12 +266,16 @@ def _list_latest_items(
         con.create_function(
             "profit_pct",
             2,
-            lambda bid, ask: compute_profit(bid, ask, fees, tick)[1],
+            lambda bid, ask: compute_profit(
+                bid, ask, fees, tick, floor_negative=not allow_negative
+            )[1],
         )
         con.create_function(
             "profit_isk",
             2,
-            lambda bid, ask: compute_profit(bid, ask, fees, tick)[0],
+            lambda bid, ask: compute_profit(
+                bid, ask, fees, tick, floor_negative=not allow_negative
+            )[0],
         )
         con.create_function(
             "deal_label",
@@ -432,6 +437,7 @@ def list_db_items(
         search=search,
         min_profit_pct=min_profit_pct,
         deal_filter=deal_filter,
+        allow_negative=True,
         default_sort="last_updated",
     )
 

--- a/tests/test_service_recommendations.py
+++ b/tests/test_service_recommendations.py
@@ -23,7 +23,7 @@ def seed_basic(con):
         INSERT INTO market_snapshots(ts_utc, type_id, station_id, best_bid, best_ask, bid_count, ask_count, jita_bid_units, jita_ask_units)
         VALUES
         ('2024-01-01 00:00:00',1,?,110,100,0,0,0,0),
-        ('2024-01-01 00:00:00',2,?,220,200,0,0,0,0)
+        ('2024-01-01 00:00:00',2,?,100,220,0,0,0,0)
         """,
         (config.STATION_ID, config.STATION_ID),
     )
@@ -59,8 +59,10 @@ def test_db_items(tmp_path, monkeypatch):
     assert data["total"] == 2
     deals = {r["deal"] for r in data["rows"]}
     assert deals <= {"Great", "Good", "Neutral", "Bad"}
+    profit_pcts = [r["profit_pct"] for r in data["rows"]]
+    assert any(p < 0 for p in profit_pcts)
+    assert any(p > 0 for p in profit_pcts)
     for row in data["rows"]:
-        assert row["profit_pct"] >= 0
         assert "last_updated" in row
         assert row["has_both_sides"] is True
 


### PR DESCRIPTION
## Summary
- Allow compute_profit to return negative results when requested
- Add flag so DB item queries show negative profits instead of always zero
- Cover negative profit scenario in service tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b22d26d57c83238d29f90cdd5235f7